### PR TITLE
fix: more consistent number formatting

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -21,7 +21,7 @@ const prodPages: Page[] = [
   {
     name: 'Borrow',
     // TODO: in the single-strategy case, we should have the deployed strategy in the config for each network.
-    route: 'strategies/0x41739c3547992ca3f2a40d110ad33afeb582eb7c/borrow',
+    route: 'strategies/0x206a9c917148cd6c290ab289599760b2eea5d983/borrow',
   },
   {
     name: 'Swap',

--- a/components/Strategies/Activity/Activity.tsx
+++ b/components/Strategies/Activity/Activity.tsx
@@ -6,6 +6,7 @@ import { Fieldset } from 'components/Fieldset';
 import { ethers } from 'ethers';
 import { humanizedTimestamp } from 'lib/duration';
 import { LendingStrategy } from 'lib/LendingStrategy';
+import { formatTokenAmount } from 'lib/numberFormat';
 import React, { useMemo } from 'react';
 import {
   ActivityByStrategyDocument,
@@ -135,11 +136,15 @@ function CollateralAdded({
   }, [debtIncreasedEvents, event]);
 
   const borrowedAmount = useMemo(() => {
-    return ethers.utils.formatUnits(
+    const bigNumAmount = ethers.utils.formatUnits(
       debtIncreasedEvent?.amount,
       lendingStrategy.token0IsUnderlying
         ? lendingStrategy.subgraphPool.token0.decimals
         : lendingStrategy.subgraphPool.token1.decimals,
+    );
+    return (
+      formatTokenAmount(parseFloat(bigNumAmount)) +
+      ` ${lendingStrategy.underlying.symbol}`
     );
   }, [debtIncreasedEvent, lendingStrategy]);
 
@@ -188,11 +193,15 @@ function CollateralRemoved({
   }, [debtDecreasedEvents, event]);
 
   const returnedAmount = useMemo(() => {
-    return ethers.utils.formatUnits(
+    const bigNumAmount = ethers.utils.formatUnits(
       debtDecreasedEvent?.amount,
       lendingStrategy.token0IsUnderlying
         ? lendingStrategy.subgraphPool.token0.decimals
         : lendingStrategy.subgraphPool.token1.decimals,
+    );
+    return (
+      formatTokenAmount(parseFloat(bigNumAmount)) +
+      ` ${lendingStrategy.underlying.symbol}`
     );
   }, [debtDecreasedEvent, lendingStrategy]);
 
@@ -224,11 +233,8 @@ function Swap({
   lendingStrategy: LendingStrategy;
 }) {
   const description = useMemo(() => {
-    const formatter = new Intl.NumberFormat('en-US', {
-      maximumFractionDigits: 2,
-    });
-    const amount0 = formatter.format(Math.abs(event.amount0));
-    const amount1 = formatter.format(Math.abs(event.amount1));
+    const amount0 = formatTokenAmount(Math.abs(event.amount0));
+    const amount1 = formatTokenAmount(Math.abs(event.amount1));
     const token0Symbol = lendingStrategy.subgraphPool.token0.symbol;
     const token1Symbol = lendingStrategy.subgraphPool.token1.symbol;
 

--- a/components/StrategiesToBorrowFrom/StrategiesToBorrowFrom.tsx
+++ b/components/StrategiesToBorrowFrom/StrategiesToBorrowFrom.tsx
@@ -3,6 +3,7 @@ import { Health } from 'components/Strategies/Health';
 import { ethers } from 'ethers';
 import { useConfig } from 'hooks/useConfig';
 import { LendingStrategy } from 'lib/LendingStrategy';
+import { formatThreeFractionDigits } from 'lib/numberFormat';
 import { StrategyPricesData } from 'lib/strategies/charts';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -154,7 +155,7 @@ export default function StrategiesToBorrowFrom({
 
                   <td className={styles.stat}>
                     <TooltipReference {...nftCapTooltip}>
-                      <p>{nftOverCap.toFixed(2)}</p>
+                      <p>{formatThreeFractionDigits(nftOverCap)}</p>
                     </TooltipReference>
                     <NFTCapTooltip
                       strategy={strategy}
@@ -165,7 +166,7 @@ export default function StrategiesToBorrowFrom({
                   </td>
                   <td className={styles.stat}>
                     <TooltipReference {...mktCtrTooltip}>
-                      <p>{markOverNorm.toFixed(2)}</p>
+                      <p>{formatThreeFractionDigits(markOverNorm)}</p>
                     </TooltipReference>
                     <MktCtrTooltip
                       strategy={strategy}

--- a/lib/numberFormat.ts
+++ b/lib/numberFormat.ts
@@ -1,0 +1,39 @@
+const LOCALE = 'en-US';
+const USDC_FORMATTER = new Intl.NumberFormat(LOCALE, {
+  notation: 'compact',
+  minimumSignificantDigits: 3,
+  maximumSignificantDigits: 3,
+});
+/**
+ * Formats a number representing a quantity of tokens consistent with our design.
+ * @param amount e.g., the result of `parseFloat(ethers.utils.formatUnits(...))`
+ * @returns amount as string, e.g.: `939`, `2.34k`
+ */
+export function formatTokenAmount(amount: number) {
+  return USDC_FORMATTER.format(amount);
+}
+
+const PERCENT_FORMATTER = new Intl.NumberFormat(LOCALE, {
+  style: 'percent',
+  maximumFractionDigits: 2,
+});
+/**
+ * Formats a number representing a percentage consistent with our design.
+ * @param ratio e.g.: `0.34`, `0.01`, `1.5532`
+ * @returns ratio as percentage string, e.g.: `34%`, `1%`, `155.32%`
+ */
+export function formatPercent(ratio: number) {
+  return PERCENT_FORMATTER.format(ratio);
+}
+
+const THREE_FRACTION_DIGIT_FORMATTER = new Intl.NumberFormat(LOCALE, {
+  maximumFractionDigits: 3,
+});
+/**
+ * Format a number to a maximum of 3 fraction digits
+ * @param n e.g.: `3`, `3.345678`
+ * @returns number with at most 3 fraction digits, e.g.: `3`, `3.345`
+ */
+export function formatThreeFractionDigits(n: number) {
+  return THREE_FRACTION_DIGIT_FORMATTER.format(n);
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/193055983-006e4fcf-bfda-4249-83e5-a32c33c7766c.png)

![image](https://user-images.githubusercontent.com/9300702/193056087-fbeee3c3-7562-41fe-ad1a-f17caae7220a.png)

Part of [NFT-552](https://linear.app/backed/issue/NFT-552/pretty-numbers). Unfortunately does not cover everything, will need to refactor how some values (e.g., percentages) are calculated to make them compatible with this approach. Also need to check with @adamgobes on some things to make sure I understand how certain values are being used.