### PR TITLE
[NFT-597] fix: remove non-null signer asserts

### DIFF
--- a/components/Strategies/TestPageContent/TestPageContent.tsx
+++ b/components/Strategies/TestPageContent/TestPageContent.tsx
@@ -5,20 +5,20 @@ import MintERC20 from './MintERC20';
 import MintCollateral from './MintCollateral';
 import { LendingStrategy } from 'lib/LendingStrategy';
 import { erc721Contract } from 'lib/contracts';
-import { useSigner } from 'wagmi';
+import { useSignerOrProvider } from 'hooks/useSignerOrProvider';
 
 type TestPageContentProps = {
   lendingStrategy: LendingStrategy;
 };
 
 export function TestPageContent({ lendingStrategy }: TestPageContentProps) {
-  const { data: signer } = useSigner();
+  const signerOrProvider = useSignerOrProvider();
   const collateral = useMemo(
     () =>
       lendingStrategy.allowedCollateral.map((ac) =>
-        erc721Contract(ac.contractAddress, signer!),
+        erc721Contract(ac.contractAddress, signerOrProvider),
       ),
-    [lendingStrategy.allowedCollateral, signer],
+    [lendingStrategy.allowedCollateral, signerOrProvider],
   );
   return (
     <div className={strategyStyles.wrapper}>

--- a/hooks/useLendingStrategy/index.ts
+++ b/hooks/useLendingStrategy/index.ts
@@ -1,0 +1,1 @@
+export { useLendingStrategy } from './useLendingStrategy';

--- a/hooks/useLendingStrategy/useLendingStrategy.ts
+++ b/hooks/useLendingStrategy/useLendingStrategy.ts
@@ -1,0 +1,36 @@
+import { useConfig } from 'hooks/useConfig';
+import { useSignerOrProvider } from 'hooks/useSignerOrProvider';
+import { useMemo } from 'react';
+import {
+  makeLendingStrategy,
+  SubgraphPool,
+  SubgraphStrategy,
+} from 'lib/LendingStrategy';
+import { ReservoirResponseData } from 'lib/oracle/reservoir';
+
+type UseLendingStrategyParams = {
+  subgraphStrategy: SubgraphStrategy;
+  subgraphPool: SubgraphPool;
+  oracleInfo: { [key: string]: ReservoirResponseData };
+};
+
+export function useLendingStrategy({
+  subgraphStrategy,
+  subgraphPool,
+  oracleInfo,
+}: UseLendingStrategyParams) {
+  const config = useConfig();
+  const signerOrProvider = useSignerOrProvider();
+
+  const lendingStrategy = useMemo(() => {
+    return makeLendingStrategy(
+      subgraphStrategy,
+      subgraphPool,
+      oracleInfo,
+      signerOrProvider,
+      config,
+    );
+  }, [config, signerOrProvider, subgraphPool, oracleInfo, subgraphStrategy]);
+
+  return lendingStrategy;
+}

--- a/pages/networks/[network]/strategies/[strategy]/borrow.tsx
+++ b/pages/networks/[network]/strategies/[strategy]/borrow.tsx
@@ -7,16 +7,14 @@ import {
 } from 'components/Strategies/BorrowPageContent';
 import {
   fetchSubgraphData,
-  makeLendingStrategy,
   SubgraphPool,
   SubgraphStrategy,
 } from 'lib/LendingStrategy';
 import { useConfig } from 'hooks/useConfig';
-import { useSigner } from 'wagmi';
-import { useMemo } from 'react';
 import { useAsyncValue } from 'hooks/useAsyncValue';
 import { ReservoirResponseData } from 'lib/oracle/reservoir';
 import { getOracleInfoFromAllowedCollateral } from 'lib/strategies';
+import { useLendingStrategy } from 'hooks/useLendingStrategy';
 
 type ServerSideProps = Omit<
   BorrowPageProps,
@@ -68,17 +66,12 @@ export default function Borrow({
   oracleInfo,
 }: ServerSideProps) {
   const config = useConfig();
-  const { data: signer } = useSigner();
 
-  const lendingStrategy = useMemo(() => {
-    return makeLendingStrategy(
-      subgraphStrategy,
-      subgraphPool,
-      oracleInfo,
-      signer!,
-      config,
-    );
-  }, [config, signer, subgraphPool, oracleInfo, subgraphStrategy]);
+  const lendingStrategy = useLendingStrategy({
+    subgraphStrategy,
+    subgraphPool,
+    oracleInfo,
+  });
 
   const pricesData = useAsyncValue(
     () =>

--- a/pages/networks/[network]/strategies/[strategy]/index.tsx
+++ b/pages/networks/[network]/strategies/[strategy]/index.tsx
@@ -5,18 +5,16 @@ import {
   StrategyOverviewContent,
   StrategyPageProps,
 } from 'components/Strategies/StrategyOverviewContent';
-import { useMemo } from 'react';
 import {
   fetchSubgraphData,
-  makeLendingStrategy,
   SubgraphPool,
   SubgraphStrategy,
 } from 'lib/LendingStrategy';
-import { useSigner } from 'wagmi';
 import { useConfig } from 'hooks/useConfig';
 import { useAsyncValue } from 'hooks/useAsyncValue';
 import { ReservoirResponseData } from 'lib/oracle/reservoir';
 import { getOracleInfoFromAllowedCollateral } from 'lib/strategies';
+import { useLendingStrategy } from 'hooks/useLendingStrategy';
 
 type ServerSideProps = Omit<
   StrategyPageProps,
@@ -68,17 +66,11 @@ export default function StrategyPage({
   subgraphPool,
 }: ServerSideProps) {
   const config = useConfig();
-  const { data: signer } = useSigner();
-
-  const lendingStrategy = useMemo(() => {
-    return makeLendingStrategy(
-      subgraphStrategy,
-      subgraphPool,
-      oracleInfo,
-      signer!,
-      config,
-    );
-  }, [config, signer, subgraphPool, oracleInfo, subgraphStrategy]);
+  const lendingStrategy = useLendingStrategy({
+    subgraphStrategy,
+    subgraphPool,
+    oracleInfo,
+  });
 
   const pricesData = useAsyncValue(
     () =>

--- a/pages/networks/[network]/strategies/[strategy]/oldstrategy.tsx
+++ b/pages/networks/[network]/strategies/[strategy]/oldstrategy.tsx
@@ -6,15 +6,13 @@ import {
 } from 'components/Strategies/OldStrategyOverviewContent';
 import {
   fetchSubgraphData,
-  makeLendingStrategy,
   SubgraphPool,
   SubgraphStrategy,
 } from 'lib/LendingStrategy';
 import { useConfig } from 'hooks/useConfig';
-import { useSigner } from 'wagmi';
-import { useMemo } from 'react';
 import { strategyPricesData } from 'lib/strategies/charts';
 import { useAsyncValue } from 'hooks/useAsyncValue';
+import { useLendingStrategy } from 'hooks/useLendingStrategy';
 
 type ServerSideProps = Omit<
   OldStrategyPageProps,
@@ -58,17 +56,12 @@ export default function OldStrategyPage({
   subgraphPool,
 }: ServerSideProps) {
   const config = useConfig();
-  const { data: signer } = useSigner();
 
-  const lendingStrategy = useMemo(() => {
-    return makeLendingStrategy(
-      subgraphStrategy,
-      subgraphPool,
-      {},
-      signer!,
-      config,
-    );
-  }, [config, signer, subgraphPool, subgraphStrategy]);
+  const lendingStrategy = useLendingStrategy({
+    subgraphStrategy,
+    subgraphPool,
+    oracleInfo: {},
+  });
 
   const pricesData = useAsyncValue(
     () =>

--- a/pages/networks/[network]/strategies/[strategy]/test.tsx
+++ b/pages/networks/[network]/strategies/[strategy]/test.tsx
@@ -1,15 +1,12 @@
 import { TestPageContent } from 'components/Strategies/TestPageContent';
-import { useConfig } from 'hooks/useConfig';
 import { configs, SupportedNetwork } from 'lib/config';
 import {
   fetchSubgraphData,
-  makeLendingStrategy,
   SubgraphPool,
   SubgraphStrategy,
 } from 'lib/LendingStrategy';
 import { GetServerSideProps } from 'next';
-import { useMemo } from 'react';
-import { useSigner } from 'wagmi';
+import { useLendingStrategy } from 'hooks/useLendingStrategy';
 
 export type TestProps = {
   subgraphStrategy: SubgraphStrategy;
@@ -47,18 +44,11 @@ export default function InKindTest({
   subgraphPool,
   subgraphStrategy,
 }: TestProps) {
-  const config = useConfig();
-  const { data: signer } = useSigner();
-
-  const lendingStrategy = useMemo(() => {
-    return makeLendingStrategy(
-      subgraphStrategy,
-      subgraphPool,
-      {},
-      signer!,
-      config,
-    );
-  }, [config, signer, subgraphPool, subgraphStrategy]);
+  const lendingStrategy = useLendingStrategy({
+    subgraphStrategy,
+    subgraphPool,
+    oracleInfo: {},
+  });
 
   return <TestPageContent lendingStrategy={lendingStrategy} />;
 }


### PR DESCRIPTION
- stop using `signer!` in favor of value from `useSignerOrProvider`
- since many instances of this were instantiating LendingStrategy, and since there was a lot of duplicate code, wrapped this in a hook