### PR TITLE
fix: don't show nav on error page

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -140,8 +140,8 @@ export function Header() {
   }, [pathname]);
 
   if (
-    (activeRoute === '' || activeRoute === 'errorPage') &&
-    !SHOW_HEADER_ON_LANDING_PAGE
+    (activeRoute === '' && !SHOW_HEADER_ON_LANDING_PAGE) ||
+    activeRoute === 'errorPage'
   ) {
     return (
       <nav className={styles['logo-only-nav']}>


### PR DESCRIPTION
Because 404 pages are statically generated at build time, we shouldn't show the nav on them because it will almost certainly be wrong (which causes weirdness).

![image](https://user-images.githubusercontent.com/9300702/204335290-995d9274-e754-4119-9386-6103dc544e16.png)
