### PR TITLE
[NFT-637] fix: handle zero ltv in VaultRow

### DIFF
--- a/components/Controllers/Loans/VaultRow.tsx
+++ b/components/Controllers/Loans/VaultRow.tsx
@@ -57,8 +57,6 @@ export function VaultRow({
     return formatTokenAmount(debtNum) + ` ${symbol}`;
   }, [debt, decimals, symbol]);
 
-  console.log({ ltv, maxLTV });
-
   return (
     <tr>
       <td>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/204548903-4db416b0-238e-4b54-bc25-7bd7fea58212.png)

Note: it's possible we're seeing these zero LTV entries because of this:
https://github.com/with-backed/v2-interface/blob/main/components/Controllers/Loans/Loans.tsx#L66