### PR TITLE
fix: contest page should not get negative uniswap quotes

### DIFF
--- a/components/LandingPageContent/PaprHeroes/HeroesLandingPageContent.tsx
+++ b/components/LandingPageContent/PaprHeroes/HeroesLandingPageContent.tsx
@@ -484,7 +484,10 @@ function LeaderboardEntry({
           {heroPlayerBalance.totalPhUSDCBalance.toFixed(2)}
         </p>
       </td>
-      <td className={`${heroPlayerBalance.netPapr > 0 ? 'green' : 'red'}`}>
+      <td
+        className={`${
+          heroPlayerBalance.netPapr >= 0 ? styles.green : styles.red
+        }`}>
         <p>
           {whiteSpaceForColumn('netPapr')}
           {heroPlayerBalance.netPapr.toFixed(2)}


### PR DESCRIPTION
The contest page was previously trying to quote the price for negative numbers (i.e. user has debt)

This PR ensures that we convert the number to its absolute value before getting its quote, then multiplying by -1 accordingly if the user indeed does owe papr.