### PR TITLE
[NFT-656] fix: Center images in collateral fieldset

### DIFF
--- a/components/Controllers/Collateral/Collateral.module.css
+++ b/components/Controllers/Collateral/Collateral.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  justify-content: center;
 }
 
 .tile {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/205931625-a292c23a-c103-4640-a40c-e62fb565bb88.png)
