### PR TITLE
[NFT-212] feat: sentry tunnel to avoid losing client errors

### DIFF
--- a/pages/api/sentry.ts
+++ b/pages/api/sentry.ts
@@ -1,0 +1,44 @@
+import { withSentry, captureException } from '@sentry/nextjs';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+// Change host appropriately if you run your own Sentry instance.
+const sentryHost = 'sentry.io';
+
+// Set knownProjectIds to an array with your Sentry project IDs which you
+// want to accept through this proxy.
+const knownProjectIds = ['4504283563753472'];
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const envelope = req.body;
+    const pieces = envelope.split('\n');
+    const header = JSON.parse(pieces[0]);
+    // DSNs are of the form `https://<key>@o<orgId>.ingest.sentry.io/<projectId>`
+    const { host, pathname } = new URL(header.dsn);
+    // Remove leading slash
+    const projectId = pathname.substring(1);
+
+    if (host !== sentryHost) {
+      throw new Error(`invalid host: ${host}`);
+    }
+
+    if (!knownProjectIds.includes(projectId)) {
+      throw new Error(`invalid project id: ${projectId}`);
+    }
+
+    const sentryIngestURL = `https://${sentryHost}/api/${projectId}/envelope/`;
+    const sentryResponse = await fetch(sentryIngestURL, {
+      method: 'POST',
+      body: envelope,
+    });
+
+    // Relay response from Sentry servers to front end
+    sentryResponse.headers.forEach((value, key) => res.setHeader(key, value));
+    res.status(sentryResponse.status).send(sentryResponse.body);
+  } catch (e) {
+    captureException(e);
+    return res.status(400).json({ status: 'invalid request' });
+  }
+}
+
+export default withSentry(handler);

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -16,4 +16,5 @@ Sentry.init({
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
+  tunnel: '/api/sentry',
 });


### PR DESCRIPTION
see:
- https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option
- https://github.com/getsentry/examples/blob/master/tunneling/nextjs/pages/api/tunnel.js