### PR TITLE
fix: sentry tunnel ingest URL

### DIFF
--- a/pages/api/sentry.ts
+++ b/pages/api/sentry.ts
@@ -2,7 +2,7 @@ import { withSentry, captureException } from '@sentry/nextjs';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 // Change host appropriately if you run your own Sentry instance.
-const sentryHost = 'sentry.io';
+const sentryHost = 'o1195560.ingest.sentry.io';
 
 // Set knownProjectIds to an array with your Sentry project IDs which you
 // want to accept through this proxy.


### PR DESCRIPTION
Looks like we have a specific sentry ingest host for our project (based on DSN). We were just using the regular sentry host that was included in the example code. Updating to the correct host in this PR.