### PR TITLE
config: next source maps

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ const { withSentryConfig } = require('@sentry/nextjs');
 const moduleExports = {
   // Your existing module.exports
   optimizeFonts: false,
+  productionBrowserSourceMaps: true,
 };
 
 const sentryWebpackPluginOptions = {


### PR DESCRIPTION
Relates to NFT-705. As far as I can tell, the sentry/next package should automatically handle source maps as long as we generate them.