### PR TITLE
fix: use NEXT_PUBLIC_ENV

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -18,7 +18,7 @@ const developmentAlchemyKey = 'BtHbvji7nhBOC943JJB2XoXMSJAh64g-';
 const prodAlchemyKey = 'aoKdUYwv3VnTO9uURR6JzpZaf-9ssuRz';
 
 const alchemyId =
-  process.env.VERCEL_ENV === 'production'
+  process.env.NEXT_PUBLIC_ENV === 'production'
     ? prodAlchemyKey
     : developmentAlchemyKey;
 


### PR DESCRIPTION
Still seeing 429s on Alchemy using the non-prod key. Switching to using `NEXT_PUBLIC_ENV` which I know for certain will be `production` on our prod deploy.

![image](https://user-images.githubusercontent.com/9300702/207642137-5ced12f1-f4a3-4840-aed7-a25cae28a6a8.png)
