### PR TITLE
NFT-734: Refactor oracle calls to use relative URL

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -34,12 +34,6 @@ const paprTrash: Config = {
   uniswapSubgraph:
     'https://api.thegraph.com/subgraphs/name/liqwiz/uniswap-v3-goerli',
   paprMemeSubgraph: goerliSubgraph,
-  oracleBaseUrl:
-    process.env.NEXT_PUBLIC_ENV === 'local'
-      ? 'http://localhost:3000'
-      : process.env.NEXT_PUBLIC_ENV === 'preview'
-      ? 'https://v2-interface-rosy.vercel.app'
-      : 'https://www.papr.wtf',
   paprUnderlyingAddress: '0x3089b47853df1b82877beef6d904a0ce98a12553',
   reservoirAPI: 'https://api-goerli.reservoir.tools',
   reservoirMarketplace: 'https://goerli-marketplace-gules.vercel.app',
@@ -64,12 +58,6 @@ const paprHero: Config = {
   uniswapSubgraph:
     'https://api.thegraph.com/subgraphs/name/liqwiz/uniswap-v3-goerli',
   paprMemeSubgraph: goerliSubgraph,
-  oracleBaseUrl:
-    process.env.NEXT_PUBLIC_ENV === 'local'
-      ? 'http://localhost:3000'
-      : process.env.NEXT_PUBLIC_ENV === 'preview'
-      ? 'https://v2-interface-rosy.vercel.app'
-      : 'https://www.papr.wtf',
   paprUnderlyingAddress: '0x68b7e050e6e2c7efe11439045c9d49813c1724b8',
   reservoirAPI: 'https://api-goerli.reservoir.tools',
   reservoirMarketplace: 'https://goerli-marketplace-gules.vercel.app',
@@ -94,7 +82,6 @@ const paprMeme = {
   uniswapSubgraph: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3',
   paprMemeSubgraph: 'TODO: update this when we have a prod subgraph',
   paprUnderlyingAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  oracleBaseUrl: '',
   reservoirAPI: 'https://api.reservoir.tools',
   reservoirMarketplace: '',
   erc721Subgraph: '',

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -302,7 +302,7 @@ export async function getOracleInfoFromAllowedCollateral(
   const oracleInfoFromAPI: ReservoirResponseData[] = await Promise.all(
     collections.map(async (collectionAddress) => {
       const req = await fetch(
-        `${configs[token].oracleBaseUrl}/api/tokens/${token}/oracle/collections/${collectionAddress}?kind=${kind}`,
+        `/api/tokens/${token}/oracle/collections/${collectionAddress}?kind=${kind}`,
         {
           method: 'POST',
         },


### PR DESCRIPTION
We never SSR oracle info now that the competition page has been removed