### PR TITLE
[NFT-840] chore: update swap widget styles

### DIFF
--- a/components/SwapPageContent/SwapPageContent.module.css
+++ b/components/SwapPageContent/SwapPageContent.module.css
@@ -4,4 +4,10 @@
   height: 100%;
   align-items: center;
   justify-content: center;
+  margin-top: 30px;
+  max-width: 640px;
+}
+
+.wrapper > div {
+  width: 100%;
 }

--- a/components/SwapPageContent/SwapPageContent.tsx
+++ b/components/SwapPageContent/SwapPageContent.tsx
@@ -3,16 +3,17 @@ import { SwapWidget, Theme } from '@uniswap/widgets';
 import '@uniswap/widgets/fonts.css';
 import { useConfig } from 'hooks/useConfig';
 import { useController } from 'hooks/useController';
+import { useTheme } from 'hooks/useTheme';
 import { useMemo } from 'react';
 import { useSigner } from 'wagmi';
 import styles from './SwapPageContent.module.css';
 
-const theme: Theme = {
+const BASE_THEME: Theme = {
   primary: '#000',
   secondary: '#000',
-  interactive: '#C6E6E1',
+  interactive: '#C6E6E1', // -20
   container: '#FFF',
-  module: '#F2F9F8',
+  module: '#F2F9F8', // -5
   accent: '#0000EE',
   outline: '#000',
   dialog: '#000',
@@ -23,6 +24,7 @@ const theme: Theme = {
 export function SwapPageContent() {
   const { paprToken, underlying } = useController();
   const { chainId, jsonRpcProvider, tokenName } = useConfig();
+  const paprTheme = useTheme();
   const provider = useSigner<JsonRpcSigner>().data?.provider;
 
   const jsonRpcUrlMap = useMemo(
@@ -50,10 +52,23 @@ export function SwapPageContent() {
     [chainId, paprToken, tokenName, underlying],
   );
 
+  const swapWidgetTheme = useMemo(() => {
+    switch (paprTheme) {
+      case 'hero':
+        return { ...BASE_THEME, interactive: '#dddbff', module: '#f8f7ff' };
+      case 'meme':
+        return { ...BASE_THEME, interactive: '#c6e6e1', module: '#f2f9f8' };
+      case 'trash':
+        return { ...BASE_THEME, interactive: '#ffd7cc', module: '#fef5f2' };
+      case 'papr':
+        return { ...BASE_THEME, interactive: '#cce0fe', module: '#f5f9ff' };
+    }
+  }, [paprTheme]);
+
   return (
     <div className={styles.wrapper}>
       <SwapWidget
-        theme={theme}
+        theme={swapWidgetTheme}
         jsonRpcUrlMap={jsonRpcUrlMap}
         provider={provider}
         tokenList={tokenList}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/215512038-12ddf519-b368-452c-bb60-a591b230ab46.png)

- widget gets color from current theme
- expanded widget to fill up to 640px width
- added margin on top