### PR TITLE
use controller.underlying instead of hardcoded USDC

### DIFF
--- a/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.tsx
+++ b/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.tsx
@@ -813,8 +813,8 @@ function LoanActionSummary({
               type="checkbox"
               onChange={() => setUsingPerpetual(!usingPerpetual)}
             />
-            {isBorrowing && <p>Swap for USDC</p>}
-            {!isBorrowing && <p>Swap from USDC</p>}
+            {isBorrowing && <p>Swap for {controller.underlying.symbol}</p>}
+            {!isBorrowing && <p>Swap from {controller.underlying.symbol}</p>}
           </div>
           <div>
             {quote && (


### PR DESCRIPTION
`formatTokenAmount` and Tooltips.tsx also seem to have hardcoded USDC references, but this is an easy one 