### PR TITLE
feat: add step prop to slider

### DIFF
--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -1,4 +1,5 @@
 import { ButtonTheme } from 'components/Button/Button';
+import { useMemo } from 'react';
 import ReactSlider from 'react-slider';
 
 import styles from './Slider.module.css';
@@ -34,6 +35,11 @@ export function Slider({
   hideBlackTrack,
   theme,
 }: SliderProps) {
+  const step = useMemo(() => {
+    const divisibleSteps = (max - min) / 100;
+    if (divisibleSteps < 1) return divisibleSteps;
+    return 1;
+  }, [max, min]);
   return (
     <>
       <div
@@ -54,6 +60,7 @@ export function Slider({
         renderTrack={renderTrack}
         min={min}
         max={max}
+        step={step}
         pearling
         onChange={onChange}
         onAfterChange={onAfterChange}


### PR DESCRIPTION
This PR adds the `step` prop to our slider. This allows for more fine grained sliding with decimal point numbers.

https://user-images.githubusercontent.com/7279416/215639567-16074db5-021f-4a15-914d-68f67f82b185.mov

