### PR TITLE
NFT-848: Projected new rate function

### DIFF
--- a/__tests__/lib/controllers/index.test.ts
+++ b/__tests__/lib/controllers/index.test.ts
@@ -1,0 +1,40 @@
+import { ethers } from 'ethers';
+import { computeNewProjectedAPR } from 'lib/controllers';
+
+jest.mock('lib/contracts', () => ({
+  jsonRpcControllerContract: jest.fn().mockReturnValue({
+    targetMarkRatioMax: () => ethers.utils.parseEther('3'),
+    targetMarkRatioMin: () => ethers.utils.parseEther('0.5'),
+    fundingPeriod: () => ethers.BigNumber.from(7776000),
+  }),
+}));
+
+describe('computeNewProjectedAPR', () => {
+  const target = 1.0;
+
+  it('returns an APR of 0% if target and mark are the same', async () => {
+    const mark = 1.0;
+    const result = await computeNewProjectedAPR(mark, target, 600, 'paprTrash');
+    expect(result).toEqual(0);
+  });
+
+  it('returns a constrained APR indicating negative interest rates if mark goes up too much', async () => {
+    let mark = 10.0;
+    let result = await computeNewProjectedAPR(mark, target, 600, 'paprTrash');
+    expect(result).toEqual(-2.8110217265187742);
+
+    mark = 20.0;
+    result = await computeNewProjectedAPR(mark, target, 600, 'paprTrash');
+    expect(result).toEqual(-2.8110217265187742);
+  });
+
+  it('returns a constrained APR indicating positive interest rates if mark goes down too much', async () => {
+    let mark = 0.1;
+    let result = await computeNewProjectedAPR(mark, target, 600, 'paprTrash');
+    expect(result).toEqual(4.4556720205165234);
+
+    mark = 0.001;
+    result = await computeNewProjectedAPR(mark, target, 600, 'paprTrash');
+    expect(result).toEqual(4.4556720205165234);
+  });
+});

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -7,12 +7,12 @@ import { OracleInfo } from 'hooks/useOracleInfo/useOracleInfo';
 import { lambertW0 } from 'lambert-w-function';
 import { configs, SupportedToken } from 'lib/config';
 import { SECONDS_IN_A_DAY, SECONDS_IN_A_YEAR } from 'lib/constants';
-import { makeProvider, Quoter } from 'lib/contracts';
+import { jsonRpcControllerContract, Quoter } from 'lib/contracts';
 import { formatBigNum } from 'lib/numberFormat';
 import { OraclePriceType, ReservoirResponseData } from 'lib/oracle/reservoir';
 import { SubgraphController } from 'lib/PaprController';
 import { percentChange } from 'lib/tokenPerformance';
-import { ERC20, ERC721, PaprController__factory } from 'types/generated/abis';
+import { ERC20, ERC721 } from 'types/generated/abis';
 
 import { ONE } from './constants';
 
@@ -329,16 +329,16 @@ export function controllerNFTValue(
   return value;
 }
 
-export async function computeNewProjectedRate(
+export async function computeNewProjectedAPR(
   newMark: number,
   target: number,
   secondsHeld: number,
   token: SupportedToken,
 ): Promise<number> {
-  const rpcProvider = makeProvider(configs[token].jsonRpcProvider, token);
-  const controller = PaprController__factory.connect(
+  const controller = jsonRpcControllerContract(
     configs[token].controllerAddress,
-    rpcProvider,
+    configs[token].jsonRpcProvider,
+    token,
   );
 
   const targetMarkRatioMax = parseFloat(

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -333,6 +333,7 @@ export function controllerNFTValue(
 export async function computeNewProjectedRate(
   newMark: number,
   target: number,
+  secondsHeld: number,
   token: SupportedToken,
 ): Promise<number> {
   const rpcProvider = makeProvider(configs[token].jsonRpcProvider, token);
@@ -349,9 +350,7 @@ export async function computeNewProjectedRate(
   );
   const fundingPeriod = (await controller.fundingPeriod()).toNumber();
 
-  const tenMinutesFromNow = getCurrentUnixTime()
-    .add(10 * 60)
-    .toNumber();
+  const tenMinutesFromNow = getCurrentUnixTime().add(secondsHeld).toNumber();
   const period = tenMinutesFromNow - getCurrentUnixTime().toNumber();
 
   const periodRatio = period / fundingPeriod;
@@ -370,6 +369,6 @@ export async function computeNewProjectedRate(
 
   const newTarget = target * m;
   const change = percentChange(target, newTarget);
-  const apr = (change / (10 * 60)) * SECONDS_IN_A_YEAR;
+  const apr = (change / secondsHeld) * SECONDS_IN_A_YEAR;
   return apr;
 }

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -8,7 +8,6 @@ import { lambertW0 } from 'lambert-w-function';
 import { configs, SupportedToken } from 'lib/config';
 import { SECONDS_IN_A_DAY, SECONDS_IN_A_YEAR } from 'lib/constants';
 import { makeProvider, Quoter } from 'lib/contracts';
-import { getCurrentUnixTime } from 'lib/duration';
 import { formatBigNum } from 'lib/numberFormat';
 import { OraclePriceType, ReservoirResponseData } from 'lib/oracle/reservoir';
 import { SubgraphController } from 'lib/PaprController';
@@ -350,10 +349,7 @@ export async function computeNewProjectedRate(
   );
   const fundingPeriod = (await controller.fundingPeriod()).toNumber();
 
-  const tenMinutesFromNow = getCurrentUnixTime().add(secondsHeld).toNumber();
-  const period = tenMinutesFromNow - getCurrentUnixTime().toNumber();
-
-  const periodRatio = period / fundingPeriod;
+  const periodRatio = secondsHeld / fundingPeriod;
   let targetMarkRatio: number;
   if (newMark === 0) {
     targetMarkRatio = targetMarkRatioMax;


### PR DESCRIPTION
Function that, when given a new mark and the current target, returns the projected APR, assuming that the new mark will hold for however long the caller wants