### PR TITLE
feat: GradientButtonLink

### DIFF
--- a/components/Button/Button.module.css
+++ b/components/Button/Button.module.css
@@ -266,6 +266,10 @@
   composes: small;
 }
 
+.gradient-button:visited {
+  color: black;
+}
+
 .gradient-button-orange {
   composes: gradient-button;
   background: linear-gradient(

--- a/components/Button/Button.module.css
+++ b/components/Button/Button.module.css
@@ -260,3 +260,42 @@
   composes: text-button;
   color: var(--highlight-success-100);
 }
+
+.gradient-button {
+  composes: button;
+  composes: small;
+}
+
+.gradient-button-orange {
+  composes: gradient-button;
+  background: linear-gradient(
+      rgba(255, 255, 255, 0.85),
+      rgba(255, 255, 255, 0.85)
+    ),
+    linear-gradient(#faff00, #ff5c00);
+}
+
+.gradient-button-orange:hover {
+  background: linear-gradient(
+      rgba(255, 255, 255, 0.75),
+      rgba(255, 255, 255, 0.75)
+    ),
+    linear-gradient(#faff00, #ff5c00);
+}
+
+.gradient-button-blue {
+  composes: gradient-button;
+  background: linear-gradient(
+      rgba(255, 255, 255, 0.85),
+      rgba(255, 255, 255, 0.85)
+    ),
+    linear-gradient(#5397FF, #00F0FF);
+}
+
+.gradient-button-blue:hover {
+  background: linear-gradient(
+      rgba(255, 255, 255, 0.75),
+      rgba(255, 255, 255, 0.75)
+    ),
+    linear-gradient(#5397FF, #00F0FF);
+}

--- a/components/Button/Button.stories.tsx
+++ b/components/Button/Button.stories.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 
 import { Button, ButtonKind, ButtonTheme } from './Button';
 import { ButtonLink } from './ButtonLink';
+import { GradientButtonLink } from './GradientButtonLink';
 import { ButtonKind as TextButtonKind, TextButton } from './TextButton';
 import { TransactionButton } from './TransactionButton';
 
@@ -97,5 +98,16 @@ export const TransactionButtons = () => (
     <TransactionButton text="Hello" />
     <TransactionButton text="Hello" completed />
     <TransactionButton text="Hello" disabled />
+  </Wrapper>
+);
+
+export const GradientButtonLinks = () => (
+  <Wrapper>
+    <GradientButtonLink href="" color="orange">
+      Henlo
+    </GradientButtonLink>
+    <GradientButtonLink href="" color="blue">
+      Henlo
+    </GradientButtonLink>
   </Wrapper>
 );

--- a/components/Button/GradientButtonLink.tsx
+++ b/components/Button/GradientButtonLink.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+import { ComponentProps, useMemo } from 'react';
+
+import styles from './Button.module.css';
+
+interface GradientButtonLinkProps extends ComponentProps<typeof Link> {
+  color: 'blue' | 'orange';
+}
+
+export function GradientButtonLink({
+  children,
+  color,
+  ...props
+}: GradientButtonLinkProps) {
+  const className = useMemo(() => styles[`gradient-button-${color}`], [color]);
+  return (
+    <Link className={className} {...props}>
+      {children}
+    </Link>
+  );
+}

--- a/components/Button/index.ts
+++ b/components/Button/index.ts
@@ -1,5 +1,6 @@
 export { Button } from './Button';
 export { ButtonLink } from './ButtonLink';
 export { CompletedButton } from './CompletedButton';
+export { GradientButtonLink } from './GradientButtonLink';
 export { TextButton } from './TextButton';
 export { TransactionButton } from './TransactionButton';


### PR DESCRIPTION
<img width="202" alt="image" src="https://user-images.githubusercontent.com/9300702/216400318-980aeb6f-246c-45bd-a19e-742574ed03d2.png">

Part of [NFT-844](https://linear.app/backed/issue/NFT-844/eng-cta-links-and-brighter-buttons), will do this piecemeal as I think we'll want to hold off on some of the changes until right before launch