### PR TITLE
[NFT-878] fix: borrow page refresh

### DIFF
--- a/components/Button/TransactionButton.tsx
+++ b/components/Button/TransactionButton.tsx
@@ -78,10 +78,12 @@ export function TransactionButton({
         message = 'Failed';
         break;
     }
-    const transactionLink = (
-      <EtherscanTransactionLink transactionHash={transactionData!.hash}>
+    const transactionLink = transactionData ? (
+      <EtherscanTransactionLink transactionHash={transactionData.hash}>
         view transaction
       </EtherscanTransactionLink>
+    ) : (
+      ''
     );
     return (
       <CompletedButton

--- a/components/Controllers/BorrowPageContent/BorrowPageContent.tsx
+++ b/components/Controllers/BorrowPageContent/BorrowPageContent.tsx
@@ -38,8 +38,8 @@ export function BorrowPageContent({ subgraphPool }: BorrowPageProps) {
   );
 
   const refresh = useCallback(() => {
-    refreshAccountNFTs({ requestPolicy: 'network-only' });
-    refreshCurrentVaults({ requestPolicy: 'network-only' });
+    refreshAccountNFTs({ requestPolicy: 'cache-and-network' });
+    refreshCurrentVaults({ requestPolicy: 'cache-and-network' });
     refreshBalance();
   }, [refreshAccountNFTs, refreshBalance, refreshCurrentVaults]);
 

--- a/hooks/useAccountNFTs.ts
+++ b/hooks/useAccountNFTs.ts
@@ -4,6 +4,7 @@ import {
   NftsForAccountAndCollectionQuery,
 } from 'types/generated/graphql/erc721';
 import { useQuery } from 'urql';
+
 import { useConfig } from './useConfig';
 
 export type AccountNFTsResponse = {


### PR DESCRIPTION
I wasn't able to exactly replicate the failure @wilsoncusack had, but I did notice some flickering on the table when depositing/withdrawing NFTs. Since the collection NFTs come straight from GraphQL and we re-execute the query when a transaction completes, my hypothesis is that the [request-policy](https://formidable.com/open-source/urql/docs/basics/document-caching/#request-policies) comes into play. Changed from `network-only` to `cache-and-network` which does seem to alleviate some jank.

Unless we catch this issue in the wild again or we come up with solid repro steps, I think this sorts it.