### PR TITLE
chore: trim first-load JS

### DIFF
--- a/components/Controllers/BorrowPageContent/BorrowPageContent.tsx
+++ b/components/Controllers/BorrowPageContent/BorrowPageContent.tsx
@@ -1,6 +1,4 @@
 import controllerStyles from 'components/Controllers/Controller.module.css';
-import { VaultDebtPicker } from 'components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker';
-import { YourPositions } from 'components/YourPositions/YourPositions';
 import { getAddress } from 'ethers/lib/utils';
 import { useAccountNFTs } from 'hooks/useAccountNFTs';
 import { useController } from 'hooks/useController';
@@ -8,11 +6,22 @@ import { useCurrentVaults } from 'hooks/useCurrentVault/useCurrentVault';
 import { useOracleInfo } from 'hooks/useOracleInfo/useOracleInfo';
 import { usePaprBalance } from 'hooks/usePaprBalance';
 import { OraclePriceType } from 'lib/oracle/reservoir';
+import dynamic from 'next/dynamic';
 import React, { useCallback, useMemo } from 'react';
 import { PoolByIdQuery } from 'types/generated/graphql/uniswapSubgraph';
 import { useAccount } from 'wagmi';
 
-import { Activity } from '../Activity';
+const YourPositions = dynamic(() =>
+  import('components/YourPositions').then((mod) => mod.YourPositions),
+);
+const Activity = dynamic(() =>
+  import('components/Controllers/Activity').then((mod) => mod.Activity),
+);
+const VaultDebtPicker = dynamic(() =>
+  import(
+    'components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker'
+  ).then((mod) => mod.VaultDebtPicker),
+);
 
 export type BorrowPageProps = {
   subgraphPool: NonNullable<PoolByIdQuery['pool']>;

--- a/components/Controllers/ControllerOverviewContent/ControllerOverviewContent.tsx
+++ b/components/Controllers/ControllerOverviewContent/ControllerOverviewContent.tsx
@@ -1,37 +1,40 @@
-import { ContractStatus } from 'components/ContractStatus';
 import { Activity } from 'components/Controllers/Activity';
 import { Auctions } from 'components/Controllers/Auctions';
-import { Collateral as CollateralComponent } from 'components/Controllers/Collateral';
 import styles from 'components/Controllers/Controller.module.css';
-import { Loans as LoansComponent } from 'components/Controllers/Loans';
-import { MarketStatus } from 'components/MarketStatus';
-import { PoolStats } from 'components/PoolStats';
-import { YourPositions as YourPositionsComponent } from 'components/YourPositions';
 import dynamic from 'next/dynamic';
-import React, { ComponentProps } from 'react';
+import React from 'react';
 import { PoolByIdQuery } from 'types/generated/graphql/uniswapSubgraph';
 
 /* lightweight-charts uses canvas and cannot be SSRed */
 const Charts = dynamic(() => import('components/Controllers/Charts/Charts'), {
   ssr: false,
 });
-const YourPositions = dynamic<ComponentProps<typeof YourPositionsComponent>>(
+const YourPositions = dynamic(
   () => import('components/YourPositions').then((mod) => mod.YourPositions),
   {
     ssr: false,
   },
 );
-const Loans = dynamic<ComponentProps<typeof LoansComponent>>(
+const Loans = dynamic(
   import('components/Controllers/Loans').then((mod) => mod.Loans),
   {
     ssr: false,
   },
 );
-const Collateral = dynamic<ComponentProps<typeof CollateralComponent>>(
+const Collateral = dynamic(
   import('components/Controllers/Collateral').then((mod) => mod.Collateral),
   {
     ssr: false,
   },
+);
+const ContractStatus = dynamic(
+  import('components/ContractStatus').then((mod) => mod.ContractStatus),
+);
+const MarketStatus = dynamic(
+  import('components/MarketStatus').then((mod) => mod.MarketStatus),
+);
+const PoolStats = dynamic(
+  import('components/PoolStats').then((mod) => mod.PoolStats),
 );
 
 export type ControllerPageProps = {

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -44,7 +44,7 @@ const LINKS: Link[] = [
 
 export function Footer() {
   return (
-    <footer className={styles.footer} data-testId="footer">
+    <footer className={styles.footer} data-testid="footer">
       <Image src={Bunny} alt="Backed Bunny Logo" height={64} />
       <ul className={styles['footer-links']}>
         {LINKS.map((link) => {

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -186,7 +186,7 @@ export function Header() {
 
   return (
     <nav
-      data-testId="header"
+      data-testid="header"
       className={[
         styles.nav,
         isHomePage ? styles.homepage : styles[theme],

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -101,6 +101,7 @@ function NavLinks({ activeRoute, isHomePage }: NavLinksProps) {
       {pages.map((p) => (
         <li key={p.name}>
           <Link
+            prefetch={false}
             href={
               p.isNetworkSpecialCase
                 ? `/${p.route}`

--- a/components/YourPositions/YourPositions.tsx
+++ b/components/YourPositions/YourPositions.tsx
@@ -1,8 +1,8 @@
+import { BigNumber } from '@ethersproject/bignumber';
 import { VaultHealth } from 'components/Controllers/Loans/VaultHealth';
 import { Fieldset } from 'components/Fieldset';
 import { Table } from 'components/Table';
-import { ethers } from 'ethers';
-import { getAddress } from 'ethers/lib/utils';
+import { formatUnits, getAddress } from 'ethers/lib/utils';
 import { useAccountNFTs } from 'hooks/useAccountNFTs';
 import { useAsyncValue } from 'hooks/useAsyncValue';
 import { useConfig } from 'hooks/useConfig';
@@ -77,11 +77,11 @@ export function YourPositions() {
     }
     const maxLoanMinusCurrentDebt = maxLoanInDebtTokens.sub(
       (currentVaults || [])
-        .map((v) => ethers.BigNumber.from(v.debt))
-        .reduce((a, b) => a.add(b), ethers.BigNumber.from(0)),
+        .map((v) => BigNumber.from(v.debt))
+        .reduce((a, b) => a.add(b), BigNumber.from(0)),
     );
     return maxLoanMinusCurrentDebt.isNegative()
-      ? ethers.BigNumber.from(0)
+      ? BigNumber.from(0)
       : maxLoanMinusCurrentDebt;
   }, [currentVaults, maxLoanInDebtTokens]);
 
@@ -92,10 +92,7 @@ export function YourPositions() {
 
     return (
       parseFloat(
-        ethers.utils.formatUnits(
-          maxLoanMinusCurrentDebt,
-          paprController.paprToken.decimals,
-        ),
+        formatUnits(maxLoanMinusCurrentDebt, paprController.paprToken.decimals),
       ) * latestMarketPrice
     ).toFixed(5);
   }, [
@@ -105,12 +102,12 @@ export function YourPositions() {
   ]);
 
   const totalPaprMemeDebt = useMemo(() => {
-    if (!currentVaults) return ethers.BigNumber.from(0);
+    if (!currentVaults) return BigNumber.from(0);
     return currentVaults
       .map((vault) => vault.debt)
       .reduce(
-        (a, b) => ethers.BigNumber.from(a).add(ethers.BigNumber.from(b)),
-        ethers.BigNumber.from(0),
+        (a, b) => BigNumber.from(a).add(BigNumber.from(b)),
+        BigNumber.from(0),
       );
   }, [currentVaults]);
 
@@ -230,10 +227,9 @@ export function VaultOverview({ vaultInfo }: VaultOverviewProps) {
   const { paprToken, underlying } = useController();
   const nftSymbol = vaultInfo.token.symbol;
   const costToClose = useAsyncValue(async () => {
-    if (ethers.BigNumber.from(vaultInfo.debt).isZero())
-      return ethers.BigNumber.from(0);
+    if (BigNumber.from(vaultInfo.debt).isZero()) return BigNumber.from(0);
     return getQuoteForSwapOutput(
-      ethers.BigNumber.from(vaultInfo.debt),
+      BigNumber.from(vaultInfo.debt),
       underlying.id,
       paprToken.id,
       tokenName as SupportedToken,
@@ -241,7 +237,7 @@ export function VaultOverview({ vaultInfo }: VaultOverviewProps) {
   }, [vaultInfo.debt, tokenName, paprToken.id, underlying.id]);
 
   if (
-    ethers.BigNumber.from(vaultInfo.debt).isZero() &&
+    BigNumber.from(vaultInfo.debt).isZero() &&
     vaultInfo.collateral.length === 0
   )
     return <></>;
@@ -273,19 +269,19 @@ export function VaultOverview({ vaultInfo }: VaultOverviewProps) {
 }
 
 type BalanceInfoProps = {
-  balance: ethers.BigNumber | null;
+  balance: BigNumber | null;
 };
 function BalanceInfo({ balance }: BalanceInfoProps) {
   const { paprToken, underlying } = useController();
   const latestMarketPrice = useLatestMarketPrice();
   const paprMemeBalance = useMemo(
-    () => ethers.BigNumber.from(balance || 0),
+    () => BigNumber.from(balance || 0),
     [balance],
   );
 
   const formattedBalance = useMemo(() => {
     const convertedBalance = parseFloat(
-      ethers.utils.formatUnits(paprMemeBalance, paprToken.decimals),
+      formatUnits(paprMemeBalance, paprToken.decimals),
     );
     return formatTokenAmount(convertedBalance) + ` ${paprToken.symbol}`;
   }, [paprMemeBalance, paprToken]);
@@ -295,7 +291,7 @@ function BalanceInfo({ balance }: BalanceInfoProps) {
     }
 
     const convertedBalance = parseFloat(
-      ethers.utils.formatUnits(paprMemeBalance, paprToken.decimals),
+      formatUnits(paprMemeBalance, paprToken.decimals),
     );
     return (
       formatTokenAmount(convertedBalance * latestMarketPrice) +

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,13 +4,11 @@ import 'styles/fonts-maru.css';
 import 'styles/global.css';
 
 import { ApplicationProviders } from 'components/ApplicationProviders';
-import { ErrorBanners } from 'components/ErrorBanners';
-import { Footer } from 'components/Footer';
-import { Header } from 'components/Header';
 import { AppWrapper } from 'components/layouts/AppWrapper';
 import { ConfigProvider } from 'hooks/useConfig';
 import { isSupportedToken, SupportedToken } from 'lib/config';
 import { AppProps } from 'next/app';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
@@ -24,6 +22,16 @@ function tokenFromPath(path: string): SupportedToken {
   // is paprHero. We will change to paprMeme when that launches.
   return 'paprHero';
 }
+
+const ErrorBanners = dynamic(() =>
+  import('components/ErrorBanners').then((mod) => mod.ErrorBanners),
+);
+const Footer = dynamic(() =>
+  import('components/Footer').then((mod) => mod.Footer),
+);
+const Header = dynamic(() =>
+  import('components/Header').then((mod) => mod.Header),
+);
 
 export default function App({ Component, pageProps }: AppProps) {
   const { asPath } = useRouter();

--- a/pages/tokens/[token]/swap/index.tsx
+++ b/pages/tokens/[token]/swap/index.tsx
@@ -1,12 +1,17 @@
 import { captureException } from '@sentry/nextjs';
 import { OpenGraph } from 'components/OpenGraph';
-import { SwapPageContent } from 'components/SwapPageContent';
 import { ControllerContextProvider } from 'hooks/useController';
 import { configs, getConfig, SupportedToken } from 'lib/config';
 import { fetchSubgraphData, SubgraphController } from 'lib/PaprController';
 import capitalize from 'lodash/capitalize';
 import { GetServerSideProps } from 'next';
+import dynamic from 'next/dynamic';
 import React from 'react';
+
+const SwapPageContent = dynamic(
+  () => import('components/SwapPageContent').then((mod) => mod.SwapPageContent),
+  {},
+);
 
 export const getServerSideProps: GetServerSideProps<SwapProps> = async (
   context,


### PR DESCRIPTION
Related to, but does not resolve, NFT-839

![image](https://user-images.githubusercontent.com/9300702/217337381-6170315c-5b0f-41af-8471-10cc7887a11c.png)

some highlights:
- swap page first-load JS is down to 1/3 of previous size
- shaved about 100kb off the overview page
- (not shown in diff screenshot) borrow page also lost about 100kb

Note that the code payload still exists, just parts of it are now in separate chunks. This will allow other tasks to get a word in edgewise in between parsing/execution of those chunks.

Additionally, removing prefetching on header links which should limit the amount of data transfer done on a given page, which can also increase breathing room.