### PR TITLE
NFT-910: Try catch uniswap quotes

### DIFF
--- a/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.tsx
+++ b/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.tsx
@@ -133,16 +133,6 @@ export function VaultDebtPicker({
     OraclePriceType.lower,
   );
 
-  const maxDebtPerNFTInUnderlying = useAsyncValue(async () => {
-    if (!oracleInfo || !maxDebtPerNFTInPerpetual) return null;
-    return getQuoteForSwap(
-      maxDebtPerNFTInPerpetual,
-      paprController.paprToken.id,
-      paprController.underlying.id,
-      tokenName as SupportedToken,
-    );
-  }, [maxDebtPerNFTInPerpetual, tokenName, paprController, oracleInfo]);
-
   const maxDebt = useMemo(() => {
     if (!maxDebtPerNFTInPerpetual) return null;
     return maxDebtPerNFTInPerpetual.mul(numCollateralForMaxDebt);
@@ -216,6 +206,7 @@ export function VaultDebtPicker({
         paprController.underlying.id,
         tokenName as SupportedToken,
       );
+      if (!quote) return null;
       const slippage = await computeSlippageForSwap(
         quote,
         paprController.paprToken,
@@ -256,6 +247,7 @@ export function VaultDebtPicker({
         paprController.paprToken.id,
         tokenName as SupportedToken,
       );
+      if (!quote) return null;
       const slippage = await computeSlippageForSwap(
         quote,
         paprController.underlying,
@@ -374,7 +366,7 @@ export function VaultDebtPicker({
           </tr>
         </thead>
         <tbody>
-          {maxDebtPerNFTInUnderlying &&
+          {maxDebtPerNFTInPerpetual &&
             userAndVaultNFTs.map((nft) => (
               <CollateralRow
                 key={`${nft.address}-${nft.tokenId}`}
@@ -388,8 +380,8 @@ export function VaultDebtPicker({
                 isLiquidated={nft.isLiquidated}
                 vaultHasCollateral={vaultHasCollateral}
                 maxBorrow={formatBigNum(
-                  maxDebtPerNFTInUnderlying,
-                  paprController.underlying.decimals,
+                  maxDebtPerNFTInPerpetual,
+                  paprController.paprToken.decimals,
                 )}
                 depositNFTs={depositNFTs}
                 withdrawNFTs={withdrawNFTs}

--- a/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.tsx
+++ b/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.tsx
@@ -37,7 +37,6 @@ import {
   useState,
 } from 'react';
 import { Input, TooltipReference, useTooltipState } from 'reakit';
-import { ERC721__factory } from 'types/generated/abis';
 import { VaultsByOwnerForControllerQuery } from 'types/generated/graphql/inKindSubgraph';
 import {
   AuctionsByNftOwnerDocument,
@@ -313,13 +312,14 @@ export function VaultDebtPicker({
     }
   }, [writeType, debtToBorrowOrRepay, underlyingToRepay, underlyingToBorrow]);
 
-  const connectedNFT = useMemo(() => {
-    return ERC721__factory.connect(collateralContractAddress, signerOrProvider);
-  }, [collateralContractAddress, signerOrProvider]);
-  // TODO we should vault.token.symbol here but vault is possibly undefined
-  // need a rework of these components, ideally we pass ERC721 token to this
-  // component as a prop
-  const nftSymbol = useAsyncValue(() => connectedNFT.symbol(), [connectedNFT]);
+  const nftSymbol = useMemo(
+    () =>
+      paprController.allowedCollateral.find(
+        (ac) =>
+          getAddress(ac.token.id) === getAddress(collateralContractAddress),
+      )!.token.symbol,
+    [paprController.allowedCollateral, collateralContractAddress],
+  );
 
   const maxLTV = useMemo(
     () =>

--- a/components/Controllers/OpenVault/VaultWriteButton.tsx
+++ b/components/Controllers/OpenVault/VaultWriteButton.tsx
@@ -112,11 +112,11 @@ export function VaultWriteButton({
       case VaultWriteType.Borrow:
         return !usingSafeTransferFrom && !collateralApproved;
       case VaultWriteType.BorrowWithSwap:
-        return !usingSafeTransferFrom && !collateralApproved;
+        return (!usingSafeTransferFrom && !collateralApproved) || !quote;
       case VaultWriteType.Repay:
         return !!errorMessage || !debtTokenApproved;
       case VaultWriteType.RepayWithSwap:
-        return !!errorMessage || !underlyingApproved;
+        return !!errorMessage || !underlyingApproved || !quote;
     }
   }, [
     writeType,
@@ -125,6 +125,7 @@ export function VaultWriteButton({
     collateralApproved,
     debtTokenApproved,
     errorMessage,
+    quote,
   ]);
 
   return (

--- a/lib/controllers/constants.ts
+++ b/lib/controllers/constants.ts
@@ -2,4 +2,4 @@ import { ethers } from 'ethers';
 
 export const ONE = ethers.BigNumber.from(10).pow(18);
 export const TICK_SPACING = 200;
-export const FEE_TIER = 1000;
+export const FEE_TIER = 10000;

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -14,7 +14,7 @@ import { SubgraphController } from 'lib/PaprController';
 import { percentChange } from 'lib/tokenPerformance';
 import { ERC20, ERC721 } from 'types/generated/abis';
 
-import { ONE } from './constants';
+import { FEE_TIER, ONE } from './constants';
 
 dayjs.extend(duration);
 
@@ -108,7 +108,7 @@ export async function getQuoteForSwap(
     const q = await quoter.callStatic.quoteExactInputSingle(
       tokenIn,
       tokenOut,
-      ethers.BigNumber.from(10).pow(4), // TODO(adamgobes): don't hardcode this
+      FEE_TIER,
       amount,
       0,
     );
@@ -129,7 +129,7 @@ export async function getQuoteForSwapOutput(
     const q = await quoter.callStatic.quoteExactOutputSingle(
       tokenIn,
       tokenOut,
-      ethers.BigNumber.from(10).pow(4), // TODO(adamgobes): don't hardcode this
+      FEE_TIER,
       amount,
       0,
     );

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -104,14 +104,18 @@ export async function getQuoteForSwap(
   tokenName: SupportedToken,
 ) {
   const quoter = Quoter(configs[tokenName].jsonRpcProvider, tokenName);
-  const q = await quoter.callStatic.quoteExactInputSingle(
-    tokenIn,
-    tokenOut,
-    ethers.BigNumber.from(10).pow(4), // TODO(adamgobes): don't hardcode this
-    amount,
-    0,
-  );
-  return q;
+  try {
+    const q = await quoter.callStatic.quoteExactInputSingle(
+      tokenIn,
+      tokenOut,
+      ethers.BigNumber.from(10).pow(4), // TODO(adamgobes): don't hardcode this
+      amount,
+      0,
+    );
+    return q;
+  } catch (_e) {
+    return null;
+  }
 }
 
 export async function getQuoteForSwapOutput(
@@ -121,14 +125,18 @@ export async function getQuoteForSwapOutput(
   tokenName: SupportedToken,
 ) {
   const quoter = Quoter(configs[tokenName].jsonRpcProvider, tokenName);
-  const q = await quoter.callStatic.quoteExactOutputSingle(
-    tokenIn,
-    tokenOut,
-    ethers.BigNumber.from(10).pow(4), // TODO(adamgobes): don't hardcode this
-    amount,
-    0,
-  );
-  return q;
+  try {
+    const q = await quoter.callStatic.quoteExactOutputSingle(
+      tokenIn,
+      tokenOut,
+      ethers.BigNumber.from(10).pow(4), // TODO(adamgobes): don't hardcode this
+      amount,
+      0,
+    );
+    return q;
+  } catch (_e) {
+    return null;
+  }
 }
 
 export async function computeLiquidationEstimation(

--- a/lib/controllers/uniswap/index.ts
+++ b/lib/controllers/uniswap/index.ts
@@ -10,6 +10,8 @@ import { IUniswapV3Pool } from 'types/generated/abis';
 
 // const poolContract = new ethers.Contract(poolAddress, IUniswapV3PoolABI, provider)
 
+export const FEE_TIER = ethers.BigNumber.from(10).pow(4);
+
 interface Immutables {
   factory: string;
   token0: string;

--- a/lib/controllers/uniswap/index.ts
+++ b/lib/controllers/uniswap/index.ts
@@ -10,8 +10,6 @@ import { IUniswapV3Pool } from 'types/generated/abis';
 
 // const poolContract = new ethers.Contract(poolAddress, IUniswapV3PoolABI, provider)
 
-export const FEE_TIER = ethers.BigNumber.from(10).pow(4);
-
 interface Immutables {
   factory: string;
   token0: string;


### PR DESCRIPTION
This fixes the issue where the borrow page does not load when the uniswap pool does not have liquidity. Instead, we just disable the loan button for the borrow with swap and repay with swap case. We should think about designs and re-work how we display quotes if we get errors from uniswap.

Created follow up for that here: https://linear.app/backed/issue/NFT-914/rework-fetching-uniswap-quotes-and-designs-for-error-states