### PR TITLE
fix: missing box-shadow

### DIFF
--- a/components/LandingPageContent/MainLandingPage/LandingPageContent.module.css
+++ b/components/LandingPageContent/MainLandingPage/LandingPageContent.module.css
@@ -385,7 +385,7 @@
   gap: 30px;
 }
 
-.meme-grid > div > img {
+.meme-grid img {
   box-shadow: 0px 5px 14px #addbc0;
 }
 


### PR DESCRIPTION
When adding the Tooltip scaffolding, accidentally broke the box-shadow on the paprMeme banner. This resolves.

![image](https://user-images.githubusercontent.com/9300702/217929751-55031256-a5cf-4caf-b9b2-ff4a5e5b205d.png)
