### PR TITLE
[NFT-921] fix: filter swaps by account

### DIFF
--- a/components/Controllers/Activity/Activity.tsx
+++ b/components/Controllers/Activity/Activity.tsx
@@ -52,11 +52,22 @@ export function Activity({
     vault,
   );
 
+  const filteredSwaps = useMemo(() => {
+    if (account && swapsData?.swaps) {
+      return swapsData.swaps.filter(
+        ({ sender, recipient }) =>
+          ethers.utils.getAddress(sender) === account ||
+          ethers.utils.getAddress(recipient) === account,
+      );
+    }
+    return swapsData?.swaps;
+  }, [account, swapsData]);
+
   const allEvents = useMemo(() => {
     const unsortedEvents = [
       ...(activityData?.addCollateralEvents || []),
       ...(activityData?.removeCollateralEvents || []),
-      ...(swapsData?.swaps && showSwaps ? swapsData.swaps : []),
+      ...(filteredSwaps && showSwaps ? filteredSwaps : []),
       ...(activityData?.auctionStartEvents.filter(
         (e) => e.auction.vault.controller.id === paprController.id,
       ) || []),
@@ -65,7 +76,7 @@ export function Activity({
       ) || []),
     ];
     return unsortedEvents.sort((a, b) => b.timestamp - a.timestamp);
-  }, [activityData, paprController.id, showSwaps, swapsData]);
+  }, [activityData, paprController.id, showSwaps, filteredSwaps]);
 
   const { feed, amountThatWillShowNext, remainingLength, showMore } =
     useShowMore(allEvents, EVENT_INCREMENT);


### PR DESCRIPTION
| overview | vault page |
| ------- | ------- |
| ![image](https://user-images.githubusercontent.com/9300702/218099555-3dbcc7b7-0c38-46f7-b690-12e55baf8894.png) | ![image](https://user-images.githubusercontent.com/9300702/218099644-0c858fc9-0823-430a-9cc2-bb81544382bb.png) |

When showing swaps and filtering by account, make sure to filter swaps by the account passed in