### PR TITLE
[NFT-919] fix: filter duplicate timestamps on chart

### DIFF
--- a/hooks/useControllerPricesData/useControllerPricesData.ts
+++ b/hooks/useControllerPricesData/useControllerPricesData.ts
@@ -170,6 +170,7 @@ function targets(
       time: t as UTCTimestamp,
     };
   });
+  console.log({ formattedTargets });
   return formattedTargets;
 }
 
@@ -207,5 +208,15 @@ function marks(
     });
   }
 
-  return formattedSwaps.filter(({ time }) => time !== OUTLIER_TIMESTAMP);
+  const result: typeof formattedSwaps = [];
+  const seenTimestamps = new Set([OUTLIER_TIMESTAMP]);
+  formattedSwaps.forEach((swap) => {
+    if (seenTimestamps.has(swap.time)) {
+      return;
+    }
+    seenTimestamps.add(swap.time);
+    result.push(swap);
+  });
+
+  return result;
 }

--- a/hooks/useControllerPricesData/useControllerPricesData.ts
+++ b/hooks/useControllerPricesData/useControllerPricesData.ts
@@ -170,7 +170,6 @@ function targets(
       time: t as UTCTimestamp,
     };
   });
-  console.log({ formattedTargets });
   return formattedTargets;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/218175664-9b397031-216f-4b11-984f-a911fcc99b6b.png)
