### PR TITLE
fix: hide 24h uniswap values for now

### DIFF
--- a/__tests__/components/Controllers/LPPageContent.test.tsx
+++ b/__tests__/components/Controllers/LPPageContent.test.tsx
@@ -37,6 +37,6 @@ describe('LPPageContent', () => {
   it('renders', () => {
     const { getByText } = render(<LPPageContent />);
 
-    getByText('$0.16');
+    getByText('$1010101.01');
   });
 });

--- a/components/PoolStats/PoolStats.tsx
+++ b/components/PoolStats/PoolStats.tsx
@@ -5,8 +5,12 @@ import { usePoolStats } from 'hooks/usePoolStats';
 import styles from './PoolStats.module.css';
 
 export function PoolStats() {
-  const { fees24h, volume24h, totalVolume, feeTier, totalValueLocked } =
-    usePoolStats();
+  const {
+    // fees24h, volume24h,
+    totalVolume,
+    feeTier,
+    totalValueLocked,
+  } = usePoolStats();
   return (
     <Fieldset legend="🦄 Pool Stats">
       <Table>
@@ -14,8 +18,8 @@ export function PoolStats() {
           <tr>
             <th>TVL</th>
             <th>Total Volume</th>
-            <th>24H Volume</th>
-            <th>24H Fees</th>
+            {/* <th>24H Volume</th>
+            <th>24H Fees</th> */}
             <th>LPs Earn</th>
           </tr>
         </thead>
@@ -23,8 +27,8 @@ export function PoolStats() {
           <tr className={styles.row}>
             <td>{totalValueLocked}</td>
             <td>{totalVolume}</td>
-            <td>{volume24h}</td>
-            <td>{fees24h}</td>
+            {/* <td>{volume24h}</td>
+            <td>{fees24h}</td> */}
             <td>{feeTier}</td>
           </tr>
         </tbody>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9300702/218580105-5a031455-85c6-4239-9143-340141c996a8.png)

Waiting on a subgraph fix, hiding these values for now since they're coming up as cumulative rather than trailing 24h