### PR TITLE
fix: all pages get subgraph data client-side

### DIFF
--- a/components/Controllers/Controller.module.css
+++ b/components/Controllers/Controller.module.css
@@ -5,4 +5,5 @@
   gap: 2rem;
   margin-top: 70px;
   margin-bottom: 140px;
+  width: 100%;
 }

--- a/components/StatusFieldset/PageLevelStatusFieldsets.tsx
+++ b/components/StatusFieldset/PageLevelStatusFieldsets.tsx
@@ -1,0 +1,47 @@
+import { useSubgraphData } from 'hooks/useSubgraphData';
+import { FunctionComponent } from 'react';
+
+import { StatusFieldset } from './StatusFieldset';
+
+export const PageLevelStatusFieldsets: FunctionComponent<
+  ReturnType<typeof useSubgraphData>
+> = ({
+  subgraphController,
+  subgraphControllerFetching,
+  subgraphPool,
+  subgraphPoolFetching,
+}) => {
+  if (!subgraphController && subgraphControllerFetching) {
+    return (
+      <StatusFieldset kind="loading">
+        Fetching controller data...
+      </StatusFieldset>
+    );
+  }
+
+  if (!subgraphController) {
+    return (
+      <StatusFieldset kind="error">
+        Error loading controller data.
+      </StatusFieldset>
+    );
+  }
+
+  if (!subgraphPool && subgraphPoolFetching) {
+    return (
+      <StatusFieldset kind="loading">
+        Fetching Uniswap pool data...
+      </StatusFieldset>
+    );
+  }
+
+  if (!subgraphPool) {
+    return (
+      <StatusFieldset kind="error">
+        Error loading Uniswap pool data.
+      </StatusFieldset>
+    );
+  }
+
+  return null;
+};

--- a/components/StatusFieldset/StatusFieldset.module.css
+++ b/components/StatusFieldset/StatusFieldset.module.css
@@ -1,0 +1,9 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  max-width: 640px;
+  gap: 2rem;
+  margin-top: 70px;
+  margin-bottom: 140px;
+  width: 100%;
+}

--- a/components/StatusFieldset/StatusFieldset.tsx
+++ b/components/StatusFieldset/StatusFieldset.tsx
@@ -1,0 +1,23 @@
+import { Fieldset } from 'components/Fieldset';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+import styles from './StatusFieldset.module.css';
+
+const ERROR_LEGEND = '💣 Error';
+const LOADING_LEGEND = '⏳ Loading';
+
+type StatusFieldsetProps = {
+  kind: 'error' | 'loading';
+};
+
+export const StatusFieldset: FunctionComponent<
+  PropsWithChildren<StatusFieldsetProps>
+> = ({ children, kind }) => {
+  return (
+    <div className={styles.wrapper}>
+      <Fieldset legend={kind === 'error' ? ERROR_LEGEND : LOADING_LEGEND}>
+        {children}
+      </Fieldset>
+    </div>
+  );
+};

--- a/components/StatusFieldset/index.ts
+++ b/components/StatusFieldset/index.ts
@@ -1,0 +1,1 @@
+export { StatusFieldset } from './StatusFieldset';

--- a/hooks/useSubgraphData/index.ts
+++ b/hooks/useSubgraphData/index.ts
@@ -1,0 +1,1 @@
+export { useSubgraphData } from './useSubgraphData';

--- a/hooks/useSubgraphData/useSubgraphData.ts
+++ b/hooks/useSubgraphData/useSubgraphData.ts
@@ -1,0 +1,59 @@
+import { captureException } from '@sentry/nextjs';
+import { useConfig } from 'hooks/useConfig';
+import { useEffect, useMemo } from 'react';
+import {
+  PaprControllerByIdDocument,
+  PaprControllerByIdQuery,
+} from 'types/generated/graphql/inKindSubgraph';
+import {
+  PoolByIdDocument,
+  PoolByIdQuery,
+} from 'types/generated/graphql/uniswapSubgraph';
+import { useQuery } from 'urql';
+
+export function useSubgraphData() {
+  const { controllerAddress, uniswapPoolAddress, uniswapSubgraph } =
+    useConfig();
+
+  const [
+    {
+      data: controllerQueryData,
+      fetching: subgraphControllerFetching,
+      error: controllerQueryError,
+    },
+  ] = useQuery<PaprControllerByIdQuery>({
+    query: PaprControllerByIdDocument,
+    variables: { id: controllerAddress },
+  });
+
+  const [{ data: poolData, fetching: subgraphPoolFetching, error: poolError }] =
+    useQuery<PoolByIdQuery>({
+      query: PoolByIdDocument,
+      variables: { id: uniswapPoolAddress },
+      context: useMemo(
+        () => ({
+          url: uniswapSubgraph,
+        }),
+        [uniswapSubgraph],
+      ),
+    });
+
+  useEffect(() => {
+    if (controllerQueryError) {
+      captureException(controllerQueryError);
+    }
+  }, [controllerQueryError]);
+
+  useEffect(() => {
+    if (poolError) {
+      captureException(poolError);
+    }
+  }, [poolError]);
+
+  return {
+    subgraphController: controllerQueryData?.paprController ?? null,
+    subgraphControllerFetching,
+    subgraphPool: poolData?.pool ?? null,
+    subgraphPoolFetching,
+  };
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -34,6 +34,8 @@ const paprHero: Config = {
   reservoirAPI: 'https://api-goerli.reservoir.tools',
   erc721Subgraph:
     'https://api.thegraph.com/subgraphs/name/adamgobes/erc721-goerli',
+  // TODO: fill this out when goerli works with latest subgraph
+  uniswapPoolAddress: '',
 };
 
 const paprMeme = {
@@ -54,6 +56,7 @@ const paprMeme = {
   reservoirAPI: 'https://api.reservoir.tools',
   erc721Subgraph:
     'https://api.thegraph.com/subgraphs/name/sunguru98/mainnet-erc721-subgraph',
+  uniswapPoolAddress: '0x238cdffc9097591d12f5c00136514fbe563f87bf',
 };
 
 export function getConfig(configName: string) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -34,8 +34,7 @@ const paprHero: Config = {
   reservoirAPI: 'https://api-goerli.reservoir.tools',
   erc721Subgraph:
     'https://api.thegraph.com/subgraphs/name/adamgobes/erc721-goerli',
-  // TODO: fill this out when goerli works with latest subgraph
-  uniswapPoolAddress: '',
+  uniswapPoolAddress: '0xa67b6d65ca6613370f280eb1a6d4c3bfaec93fb3',
 };
 
 const paprMeme = {

--- a/pages/tokens/[token]/auctions/[id].tsx
+++ b/pages/tokens/[token]/auctions/[id].tsx
@@ -1,25 +1,22 @@
-import { captureException } from '@sentry/nextjs';
 import { Activity } from 'components/Controllers/Activity';
 import { AuctionPageContent } from 'components/Controllers/AuctionPageContent/AuctionPageContent';
 import controllerStyles from 'components/Controllers/Controller.module.css';
 import { Custom404 } from 'components/Custom404';
-import { ControllerContextProvider, PaprController } from 'hooks/useController';
+import { PageLevelStatusFieldsets } from 'components/StatusFieldset/PageLevelStatusFieldsets';
+import { ControllerContextProvider } from 'hooks/useController';
 import { OracleInfoProvider } from 'hooks/useOracleInfo/useOracleInfo';
-import { configs, getConfig, SupportedToken } from 'lib/config';
+import { useSubgraphData } from 'hooks/useSubgraphData';
+import { getConfig, SupportedToken } from 'lib/config';
 import { generateVaultId } from 'lib/controllers/vaults';
-import { fetchSubgraphData } from 'lib/PaprController';
 import { GetServerSideProps } from 'next';
 import { useCallback, useMemo } from 'react';
 import {
   AuctionDocument,
   AuctionQuery,
 } from 'types/generated/graphql/inKindSubgraph';
-import { PoolByIdQuery } from 'types/generated/graphql/uniswapSubgraph';
 import { useQuery } from 'urql';
 
 type AuctionProps = {
-  subgraphController: PaprController;
-  subgraphPool: NonNullable<PoolByIdQuery['pool']>;
   auctionId: string;
 };
 
@@ -35,37 +32,24 @@ export const getServerSideProps: GetServerSideProps<AuctionProps> = async (
     };
   }
 
-  const controllerSubgraphData = await fetchSubgraphData(
-    address,
-    configs[token].uniswapSubgraph,
-    token,
-  );
-
-  if (!controllerSubgraphData) {
-    const e = new Error(`subgraph data for controller ${address} not found`);
-    captureException(e);
-    throw e;
-  }
-
-  const { paprController, pool } = controllerSubgraphData;
-
   return {
     props: {
-      subgraphController: paprController,
-      subgraphPool: pool,
       auctionId: context.params?.id as string,
     },
   };
 };
 
-export default function Auction({
-  subgraphController,
-  subgraphPool,
-  auctionId,
-}: AuctionProps) {
+export default function Auction({ auctionId }: AuctionProps) {
+  const subgraphData = useSubgraphData();
+
   const collections = useMemo(
-    () => subgraphController.allowedCollateral.map((c) => c.token.id),
-    [subgraphController.allowedCollateral],
+    () =>
+      subgraphData.subgraphController
+        ? subgraphData.subgraphController.allowedCollateral.map(
+            (c) => c.token.id,
+          )
+        : [],
+    [subgraphData.subgraphController],
   );
 
   const [{ data: auctionQueryResult, fetching }, reexecuteQuery] =
@@ -79,17 +63,21 @@ export default function Auction({
   }, [auctionQueryResult]);
 
   const auctionVaultId = useMemo(() => {
-    if (!auction) return '';
+    if (!auction || !subgraphData.subgraphController) return '';
     return generateVaultId(
-      subgraphController.id,
+      subgraphData.subgraphController.id,
       auction.vault.account,
       auction.auctionAssetContract.id,
     );
-  }, [subgraphController.id, auction]);
+  }, [subgraphData.subgraphController, auction]);
 
   const refresh = useCallback(() => {
     reexecuteQuery({ requestPolicy: 'network-only' });
   }, [reexecuteQuery]);
+
+  if (!subgraphData.subgraphController || !subgraphData.subgraphPool) {
+    return <PageLevelStatusFieldsets {...subgraphData} />;
+  }
 
   if (!fetching && !auction) {
     return <Custom404 />;
@@ -101,11 +89,11 @@ export default function Auction({
 
   return (
     <OracleInfoProvider collections={collections}>
-      <ControllerContextProvider value={subgraphController}>
+      <ControllerContextProvider value={subgraphData.subgraphController}>
         <div className={controllerStyles.wrapper}>
           <AuctionPageContent auction={auction} refresh={refresh} />
           <Activity
-            subgraphPool={subgraphPool}
+            subgraphPool={subgraphData.subgraphPool}
             vault={auctionVaultId}
             showSwaps={false}
           />

--- a/pages/tokens/[token]/borrow.tsx
+++ b/pages/tokens/[token]/borrow.tsx
@@ -1,32 +1,15 @@
-import { captureException } from '@sentry/nextjs';
-import {
-  BorrowPageContent,
-  BorrowPageProps,
-} from 'components/Controllers/BorrowPageContent';
+import { BorrowPageContent } from 'components/Controllers/BorrowPageContent';
 import { OpenGraph } from 'components/OpenGraph';
+import { PageLevelStatusFieldsets } from 'components/StatusFieldset/PageLevelStatusFieldsets';
 import { useConfig } from 'hooks/useConfig';
 import { ControllerContextProvider } from 'hooks/useController';
 import { OracleInfoProvider } from 'hooks/useOracleInfo/useOracleInfo';
-import { configs, getConfig, SupportedToken } from 'lib/config';
-import {
-  fetchSubgraphData,
-  SubgraphController,
-  SubgraphPool,
-} from 'lib/PaprController';
+import { useSubgraphData } from 'hooks/useSubgraphData';
+import { getConfig, SupportedToken } from 'lib/config';
 import { GetServerSideProps } from 'next';
 import { useMemo } from 'react';
 
-type ServerSideProps = Omit<
-  BorrowPageProps,
-  'paprController' | 'pricesData'
-> & {
-  subgraphController: SubgraphController;
-  subgraphPool: SubgraphPool;
-};
-
-export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (
-  context,
-) => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
   const token = context.params?.token as SupportedToken;
   const address: string | undefined =
     getConfig(token)?.controllerAddress?.toLocaleLowerCase();
@@ -36,45 +19,34 @@ export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (
     };
   }
 
-  const controllerSubgraphData = await fetchSubgraphData(
-    address,
-    configs[token].uniswapSubgraph,
-    token,
-  );
-
-  if (!controllerSubgraphData) {
-    const e = new Error(`subgraph data for controller ${address} not found`);
-    captureException(e);
-    throw e;
-  }
-
-  const { pool, paprController } = controllerSubgraphData;
-
   return {
-    props: {
-      controllerAddress: address,
-      subgraphController: paprController,
-      subgraphPool: pool,
-    },
+    props: {},
   };
 };
 
-export default function Borrow({
-  subgraphController,
-  subgraphPool,
-}: ServerSideProps) {
+export default function Borrow() {
   const config = useConfig();
+  const subgraphData = useSubgraphData();
 
   const collections = useMemo(
-    () => subgraphController.allowedCollateral.map((c) => c.token.id),
-    [subgraphController.allowedCollateral],
+    () =>
+      subgraphData.subgraphController
+        ? subgraphData.subgraphController.allowedCollateral.map(
+            (c) => c.token.id,
+          )
+        : [],
+    [subgraphData.subgraphController],
   );
+
+  if (!subgraphData.subgraphController || !subgraphData.subgraphPool) {
+    return <PageLevelStatusFieldsets {...subgraphData} />;
+  }
 
   return (
     <OracleInfoProvider collections={collections}>
-      <ControllerContextProvider value={subgraphController}>
+      <ControllerContextProvider value={subgraphData.subgraphController}>
         <OpenGraph title={`${config.tokenName} | Borrow`} />
-        <BorrowPageContent subgraphPool={subgraphPool} />
+        <BorrowPageContent subgraphPool={subgraphData.subgraphPool} />
       </ControllerContextProvider>
     </OracleInfoProvider>
   );

--- a/pages/tokens/[token]/lp/index.tsx
+++ b/pages/tokens/[token]/lp/index.tsx
@@ -5,7 +5,6 @@ import { useConfig } from 'hooks/useConfig';
 import { ControllerContextProvider } from 'hooks/useController';
 import { useSubgraphData } from 'hooks/useSubgraphData';
 import { getConfig, SupportedToken } from 'lib/config';
-import { subgraphController } from 'lib/mockData/mockPaprController';
 import capitalize from 'lodash/capitalize';
 import { GetServerSideProps } from 'next';
 import React from 'react';
@@ -34,7 +33,7 @@ export default function LP() {
   }
 
   return (
-    <ControllerContextProvider value={subgraphController}>
+    <ControllerContextProvider value={subgraphData.subgraphController}>
       <OpenGraph title={`Backed | ${capitalize(network)} | LP`} />
       <LPPageContent />
     </ControllerContextProvider>

--- a/pages/tokens/[token]/lp/index.tsx
+++ b/pages/tokens/[token]/lp/index.tsx
@@ -1,21 +1,16 @@
-import { captureException } from '@sentry/nextjs';
 import { LPPageContent } from 'components/Controllers/LPPageContent';
 import { OpenGraph } from 'components/OpenGraph';
+import { PageLevelStatusFieldsets } from 'components/StatusFieldset/PageLevelStatusFieldsets';
 import { useConfig } from 'hooks/useConfig';
 import { ControllerContextProvider } from 'hooks/useController';
-import { configs, getConfig, SupportedToken } from 'lib/config';
-import { fetchSubgraphData, SubgraphController } from 'lib/PaprController';
+import { useSubgraphData } from 'hooks/useSubgraphData';
+import { getConfig, SupportedToken } from 'lib/config';
+import { subgraphController } from 'lib/mockData/mockPaprController';
 import capitalize from 'lodash/capitalize';
 import { GetServerSideProps } from 'next';
 import React from 'react';
 
-type ServerSideProps = {
-  subgraphController: SubgraphController;
-};
-
-export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (
-  context,
-) => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
   const token = context.params?.token as SupportedToken;
   const address: string | undefined =
     getConfig(token)?.controllerAddress?.toLocaleLowerCase();
@@ -25,29 +20,19 @@ export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (
     };
   }
 
-  const controllerSubgraphData = await fetchSubgraphData(
-    address,
-    configs[token].uniswapSubgraph,
-    token,
-  );
-
-  if (!controllerSubgraphData) {
-    const e = new Error(`subgraph data for controller ${address} not found`);
-    captureException(e);
-    throw e;
-  }
-
-  const { paprController } = controllerSubgraphData;
-
   return {
-    props: {
-      subgraphController: paprController,
-    },
+    props: {},
   };
 };
 
-export default function LP({ subgraphController }: ServerSideProps) {
+export default function LP() {
   const { network } = useConfig();
+  const subgraphData = useSubgraphData();
+
+  if (!subgraphData.subgraphController) {
+    return <PageLevelStatusFieldsets {...subgraphData} />;
+  }
+
   return (
     <ControllerContextProvider value={subgraphController}>
       <OpenGraph title={`Backed | ${capitalize(network)} | LP`} />

--- a/pages/tokens/[token]/test.tsx
+++ b/pages/tokens/[token]/test.tsx
@@ -1,17 +1,11 @@
-import { captureException } from '@sentry/nextjs';
 import { TestPageContent } from 'components/Controllers/TestPageContent';
-import { ControllerContextProvider, PaprController } from 'hooks/useController';
-import { configs, getConfig, SupportedToken } from 'lib/config';
-import { fetchSubgraphData } from 'lib/PaprController';
+import { PageLevelStatusFieldsets } from 'components/StatusFieldset/PageLevelStatusFieldsets';
+import { ControllerContextProvider } from 'hooks/useController';
+import { useSubgraphData } from 'hooks/useSubgraphData';
+import { getConfig, SupportedToken } from 'lib/config';
 import { GetServerSideProps } from 'next';
 
-export type TestProps = {
-  subgraphController: PaprController;
-};
-
-export const getServerSideProps: GetServerSideProps<TestProps> = async (
-  context,
-) => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
   const token = context.params?.token as SupportedToken;
   const address: string | undefined =
     getConfig(token)?.controllerAddress?.toLocaleLowerCase();
@@ -21,30 +15,20 @@ export const getServerSideProps: GetServerSideProps<TestProps> = async (
     };
   }
 
-  const controllerSubgraphData = await fetchSubgraphData(
-    address,
-    configs[token].uniswapSubgraph,
-    token,
-  );
-
-  if (!controllerSubgraphData) {
-    const e = new Error(`subgraph data for controller ${address} not found`);
-    captureException(e);
-    throw e;
-  }
-
-  const { paprController } = controllerSubgraphData;
-
   return {
-    props: {
-      subgraphController: paprController,
-    },
+    props: {},
   };
 };
 
-export default function InKindTest({ subgraphController }: TestProps) {
+export default function InKindTest() {
+  const subgraphData = useSubgraphData();
+
+  if (!subgraphData.subgraphController) {
+    return <PageLevelStatusFieldsets {...subgraphData} />;
+  }
+
   return (
-    <ControllerContextProvider value={subgraphController}>
+    <ControllerContextProvider value={subgraphData.subgraphController}>
       <TestPageContent />
     </ControllerContextProvider>
   );


### PR DESCRIPTION
We ran into a weird issue with getting our subgraph data on server side. This PR introduces a way for us to keep the benefits of always having a subgraph defined in our leaf nodes, but allows us to fetch data client side