### PR TITLE
[NFT-937] fix: slider working on mobile

### DIFF
--- a/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.module.css
+++ b/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.module.css
@@ -54,6 +54,10 @@
   color: #888888;
 }
 
+.slider-wrapper {
+  overflow: hidden;
+}
+
 .slider {
   margin-top: -18px;
   margin-bottom: 30px;


### PR DESCRIPTION
This should stop the slider from breaking the borrow page on mobile. Pending testing.