### PR TITLE
NFT-933: Refactor impact projection to not rely on controller prices data

### DIFF
--- a/codegen/inKind.yml
+++ b/codegen/inKind.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://api.goldsky.com/api/public/project_cl9fqfatx1kql0hvkak9eesug/subgraphs/papr/0.1.95/gn'
+schema: 'https://api.goldsky.com/api/public/project_cl9fqfatx1kql0hvkak9eesug/subgraphs/papr/0.1.96/gn'
 documents: './graphql/inKind/**/*.graphql'
 generates:
   types/generated/graphql/inKindSubgraph.ts:

--- a/components/SwapPageContent/ImpactProjection.tsx
+++ b/components/SwapPageContent/ImpactProjection.tsx
@@ -161,7 +161,7 @@ function ImpactProjectionLoaded({
           />
           <PriceProjection
             kind="target"
-            currentPrice={currentTargetNumber}
+            currentPrice={newTargetNumber}
             newPrice={projectedData?.newTarget || null}
           />
         </div>

--- a/components/SwapPageContent/ImpactProjection.tsx
+++ b/components/SwapPageContent/ImpactProjection.tsx
@@ -95,7 +95,6 @@ function ImpactProjectionLoaded({
   ]);
 
   useEffect(() => {
-    console.log({ paprPrice, newTargetNumber });
     setProjectedData(
       computeNewProjectedAPR(
         paprPrice,

--- a/graphql/inKind/fragments/allPaprControllerProperties.graphql
+++ b/graphql/inKind/fragments/allPaprControllerProperties.graphql
@@ -12,6 +12,7 @@ fragment allPaprControllerProperties on PaprController {
   maxLTV
   fundingPeriod
   target
+  lastUpdated
   allowedCollateral(where: { allowed: true }) {
     id
     token {

--- a/hooks/useController/useController.ts
+++ b/hooks/useController/useController.ts
@@ -29,6 +29,8 @@ export interface PaprController {
   poolAddress: string;
   maxLTV: BigNumberish;
   fundingPeriod: BigNumberish;
+  target: BigNumberish;
+  lastUpdated: number;
   vaults?:
     | {
         id: string;

--- a/hooks/useControllerPricesData/useControllerPricesData.ts
+++ b/hooks/useControllerPricesData/useControllerPricesData.ts
@@ -6,6 +6,7 @@ import { TargetUpdate, useTarget } from 'hooks/useTarget';
 import { useUniswapSwapsByPool } from 'hooks/useUniswapSwapsByPool';
 import { ControllerPricesData } from 'lib/controllers/charts';
 import { price } from 'lib/controllers/charts/mark';
+import { uniSubgraphTokenToToken } from 'lib/uniswapSubgraph';
 import { UTCTimestamp } from 'lightweight-charts';
 import { useMemo } from 'react';
 import {
@@ -26,7 +27,7 @@ type ControllerPricesDataReturn =
   | { pricesData: null; fetching: false; error: CombinedError };
 
 export function useControllerPricesData(): ControllerPricesDataReturn {
-  const { uniswapSubgraph } = useConfig();
+  const { uniswapSubgraph, chainId } = useConfig();
   const { id, poolAddress, underlying } = useController();
   const newTarget = useTarget();
 
@@ -100,8 +101,9 @@ export function useControllerPricesData(): ControllerPricesDataReturn {
       baseCurrency,
       quoteCurrency,
       poolData?.pool?.token0 as Token,
+      chainId,
     );
-  }, [baseCurrency, poolData, quoteCurrency, swapsQuery]);
+  }, [baseCurrency, poolData, quoteCurrency, swapsQuery, chainId]);
 
   const targetValues = useMemo(() => {
     if (!targetUpdatesData?.targetUpdates || !newTarget) {
@@ -184,6 +186,7 @@ function marks(
   baseCurrency: Token,
   quoteCurrency: Token,
   token0: Token,
+  chainId: number,
 ) {
   const now = Math.floor(Date.now() / 1000);
 
@@ -194,7 +197,12 @@ function marks(
   const formattedSwaps = sortedSwaps.map(({ sqrtPriceX96, timestamp }) => {
     return {
       value: parseFloat(
-        price(sqrtPriceX96, baseCurrency, quoteCurrency, token0).toFixed(),
+        price(
+          sqrtPriceX96,
+          uniSubgraphTokenToToken(baseCurrency, chainId),
+          uniSubgraphTokenToToken(quoteCurrency, chainId),
+          uniSubgraphTokenToToken(token0, chainId),
+        ).toFixed(),
       ),
       time: parseInt(timestamp) as UTCTimestamp,
     };

--- a/hooks/useControllerPricesData/useControllerPricesData.ts
+++ b/hooks/useControllerPricesData/useControllerPricesData.ts
@@ -198,7 +198,7 @@ function marks(
     return {
       value: parseFloat(
         price(
-          sqrtPriceX96,
+          ethers.BigNumber.from(sqrtPriceX96),
           uniSubgraphTokenToToken(baseCurrency, chainId),
           uniSubgraphTokenToToken(quoteCurrency, chainId),
           uniSubgraphTokenToToken(token0, chainId),

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -50,7 +50,7 @@ const paprMeme = {
   paprTokenAddress: '0x320aaab3038bc08317f5a4be19ea1d9608551d79',
   uniswapSubgraph: 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3',
   paprSubgraph:
-    'https://api.goldsky.com/api/public/project_cl9fqfatx1kql0hvkak9eesug/subgraphs/papr/0.1.95/gn',
+    'https://api.goldsky.com/api/public/project_cl9fqfatx1kql0hvkak9eesug/subgraphs/papr/0.1.96/gn',
   reservoirAPI: 'https://api.reservoir.tools',
   erc721Subgraph:
     'https://api.thegraph.com/subgraphs/name/sunguru98/mainnet-erc721-subgraph',

--- a/lib/controllers/charts/mark.ts
+++ b/lib/controllers/charts/mark.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers';
 import { Q192 } from 'lib/constants';
 
 export function price(
-  sqrtPriceX96: number,
+  sqrtPriceX96: ethers.BigNumber,
   baseCurrency: Token,
   quoteCurrency: Token,
   token0: Token,
@@ -13,9 +13,9 @@ export function price(
     quoteCurrency,
     token0.address !== quoteCurrency.address
       ? Q192.toString()
-      : ethers.BigNumber.from(sqrtPriceX96).mul(sqrtPriceX96).toString(),
+      : sqrtPriceX96.mul(sqrtPriceX96).toString(),
     token0.address === quoteCurrency.address
       ? Q192.toString()
-      : ethers.BigNumber.from(sqrtPriceX96).mul(sqrtPriceX96).toString(),
+      : sqrtPriceX96.mul(sqrtPriceX96).toString(),
   );
 }

--- a/lib/controllers/charts/mark.ts
+++ b/lib/controllers/charts/mark.ts
@@ -1,32 +1,21 @@
 import { Price, Token } from '@uniswap/sdk-core';
 import { ethers } from 'ethers';
 import { Q192 } from 'lib/constants';
-import { Token as UniSubgraphToken } from 'types/generated/graphql/uniswapSubgraph';
 
 export function price(
   sqrtPriceX96: number,
-  baseCurrency: UniSubgraphToken,
-  quoteCurrency: UniSubgraphToken,
-  token0: UniSubgraphToken,
+  baseCurrency: Token,
+  quoteCurrency: Token,
+  token0: Token,
 ): Price<Token, Token> {
   return new Price(
-    subgraphTokenToToken(baseCurrency),
-    subgraphTokenToToken(quoteCurrency),
-    token0.id !== quoteCurrency.id
+    baseCurrency,
+    quoteCurrency,
+    token0.address !== quoteCurrency.address
       ? Q192.toString()
       : ethers.BigNumber.from(sqrtPriceX96).mul(sqrtPriceX96).toString(),
-    token0.id === quoteCurrency.id
+    token0.address === quoteCurrency.address
       ? Q192.toString()
       : ethers.BigNumber.from(sqrtPriceX96).mul(sqrtPriceX96).toString(),
-  );
-}
-
-function subgraphTokenToToken(token: UniSubgraphToken): Token {
-  return new Token(
-    1,
-    token.id,
-    parseInt(token.decimals),
-    token.symbol,
-    token.name,
   );
 }

--- a/lib/uniswapSubgraph.ts
+++ b/lib/uniswapSubgraph.ts
@@ -6,6 +6,7 @@ import {
   SqrtPricesByPoolQuery,
   SwapsByPoolDocument,
   SwapsByPoolQuery,
+  Token as UniSubgraphToken,
 } from 'types/generated/graphql/uniswapSubgraph';
 
 import { ERC20Token } from './controllers';
@@ -62,6 +63,19 @@ export async function subgraphUniswapPoolById(
   return data || null;
 }
 
-export function subgraphTokenToToken(token: ERC20Token, chainId: number) {
+export function uniSubgraphTokenToToken(
+  token: UniSubgraphToken,
+  chainId: number,
+): Token {
+  return new Token(
+    chainId,
+    token.id,
+    parseInt(token.decimals),
+    token.symbol,
+    token.name,
+  );
+}
+
+export function erc20TokenToToken(token: ERC20Token, chainId: number): Token {
   return new Token(chainId, token.id, token.decimals, token.symbol, token.name);
 }


### PR DESCRIPTION
This PR refactors all instances of computing the projected APR after a swap to not rely on all controller prices data, and instead fetch newTarget, target, and lastUpdated from a combination of smaller hooks and the subgraph.

This also refactors the impact projection on the swap page to manually fetch a quote from the uni Quoter to determine what the sqrtPrice after the trade would be. We then convert that sqrtPrice to a price to use for the impact projection.