### PR TITLE
chore: factor out BLOCKS_IN_A_DAY

### DIFF
--- a/hooks/usePoolStats/usePoolStats.ts
+++ b/hooks/usePoolStats/usePoolStats.ts
@@ -1,5 +1,6 @@
 import { useConfig } from 'hooks/useConfig';
 import { useController } from 'hooks/useController';
+import { BLOCKS_IN_A_DAY } from 'lib/constants';
 import { formatDollars, formatPercent } from 'lib/numberFormat';
 import { useMemo } from 'react';
 import {
@@ -16,10 +17,6 @@ const NO_DATA = '---';
 
 // We don't want to refresh the pool data on every block number
 const BLOCK_NUMBER_CACHE_TIME = 1000 * 60 * 60;
-
-// Assuming 12s per block, one day ago is current block number
-// minus 7200.
-const BLOCKS_IN_A_DAY = 7200;
 
 export function usePoolStats() {
   const blockNumber = useBlockNumber({ cacheTime: BLOCK_NUMBER_CACHE_TIME });

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -43,3 +43,7 @@ export const OPENGRAPH_DEFAULT_DESCRIPTION =
 // Fri Apr 23 2021 09:42:55 GMT+0000 (beginning of Uniswap V3, can probably make this beginning of papr)
 export const UNISWAP_SUBGRAPH_START = 1619170975;
 export const UNISWAP_SUBGRAPH_END = Date.now() / 1000;
+
+// Assuming 12s per block, one day ago is current block number
+// minus 7200.
+export const BLOCKS_IN_A_DAY = 7200;


### PR DESCRIPTION
Moving this into our constants folder because we're going to use it in other contexts. Just reducing the diff noise in the main PR by doing this separately.