### PR TITLE
refactor: VaultHealth uses Vault type

### DIFF
--- a/components/Controllers/Loans/VaultHealth.tsx
+++ b/components/Controllers/Loans/VaultHealth.tsx
@@ -2,24 +2,30 @@ import { HealthBar } from 'components/HealthBar';
 import { Tooltip } from 'components/Tooltip';
 import { ethers } from 'ethers';
 import { useController } from 'hooks/useController';
+import { useLTV } from 'hooks/useLTV';
 import { convertOneScaledValue } from 'lib/controllers';
 import { formatPercent } from 'lib/numberFormat';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { TooltipReference, useTooltipState } from 'reakit/Tooltip';
+import { SubgraphVault } from 'types/SubgraphVault';
 
 import styles from './Loans.module.css';
 
 type VaultHealthProps = {
-  ltv: number;
+  vault: SubgraphVault;
 };
-export function VaultHealth({ ltv }: VaultHealthProps) {
+export function VaultHealth({ vault }: VaultHealthProps) {
   const healthTooltip = useTooltipState();
   const { maxLTV } = useController();
+  const ltv = useLTV(vault?.token.id, vault?.collateralCount, vault.debt);
   const formattedMaxLTV = convertOneScaledValue(
     ethers.BigNumber.from(maxLTV),
     4,
   );
-  const ratio = ltv / formattedMaxLTV;
+  const ratio = useMemo(
+    () => (ltv ? ltv / formattedMaxLTV : 0),
+    [formattedMaxLTV, ltv],
+  );
 
   return (
     <>
@@ -30,7 +36,7 @@ export function VaultHealth({ ltv }: VaultHealthProps) {
         <div className={styles.tooltip}>
           <div>
             <span>Current LTV</span>
-            <span>{formatPercent(ltv)}</span>
+            <span>{ltv ? formatPercent(ltv) : '...'}</span>
           </div>
           <div>
             <span>Max LTV</span>

--- a/components/Controllers/Loans/VaultRow.tsx
+++ b/components/Controllers/Loans/VaultRow.tsx
@@ -6,11 +6,11 @@ import { useLTV } from 'hooks/useLTV';
 import { formatPercent, formatTokenAmount } from 'lib/numberFormat';
 import Link from 'next/link';
 import React, { useMemo } from 'react';
-import { Vault } from 'types/generated/graphql/inKindSubgraph';
+import { SubgraphVault } from 'types/SubgraphVault';
 
 type VaultRowProps = {
   account: string;
-  vault: Pick<Vault, 'debt' | 'token' | 'collateralCount' | 'id'>;
+  vault: SubgraphVault;
 };
 export function VaultRow({ account, vault }: VaultRowProps) {
   const { paprToken } = useController();
@@ -44,7 +44,9 @@ export function VaultRow({ account, vault }: VaultRowProps) {
       </td>
       <td>{formattedDebt}</td>
       <td>{formattedLTV}</td>
-      <td>{ltv ? <VaultHealth ltv={ltv} /> : '...'}</td>
+      <td>
+        <VaultHealth vault={vault} />
+      </td>
     </tr>
   );
 }

--- a/components/YourPositions/YourPositions.tsx
+++ b/components/YourPositions/YourPositions.tsx
@@ -9,7 +9,6 @@ import { useConfig } from 'hooks/useConfig';
 import { useController } from 'hooks/useController';
 import { useCurrentVaults } from 'hooks/useCurrentVault/useCurrentVault';
 import { useLatestMarketPrice } from 'hooks/useLatestMarketPrice';
-import { useLTV } from 'hooks/useLTV';
 import { useMaxDebt } from 'hooks/useMaxDebt';
 import { OracleInfo, useOracleInfo } from 'hooks/useOracleInfo/useOracleInfo';
 import { usePaprBalance } from 'hooks/usePaprBalance';
@@ -18,7 +17,7 @@ import { getQuoteForSwap, getQuoteForSwapOutput } from 'lib/controllers';
 import { formatBigNum, formatTokenAmount } from 'lib/numberFormat';
 import { OraclePriceType } from 'lib/oracle/reservoir';
 import { useMemo } from 'react';
-import { VaultsByOwnerForControllerQuery } from 'types/generated/graphql/inKindSubgraph';
+import { SubgraphVault } from 'types/SubgraphVault';
 import { useAccount, useNetwork } from 'wagmi';
 
 import styles from './YourPositions.module.css';
@@ -228,16 +227,11 @@ export function YourPositions() {
 
 type VaultOverviewProps = {
   oracleInfo: OracleInfo;
-  vaultInfo: VaultsByOwnerForControllerQuery['vaults']['0'];
+  vaultInfo: SubgraphVault;
 };
 
 export function VaultOverview({ vaultInfo }: VaultOverviewProps) {
   const { tokenName } = useConfig();
-  const ltv = useLTV(
-    vaultInfo.token.id,
-    vaultInfo.collateralCount,
-    vaultInfo.debt,
-  );
   const { paprToken, underlying } = useController();
   const nftSymbol = vaultInfo.token.symbol;
   const costToClose = useAsyncValue(async () => {
@@ -277,7 +271,7 @@ export function VaultOverview({ vaultInfo }: VaultOverviewProps) {
         </p>
       </td>
       <td>
-        <VaultHealth ltv={ltv || 0} />
+        <VaultHealth vault={vaultInfo} />
       </td>
     </tr>
   );

--- a/types/SubgraphVault.ts
+++ b/types/SubgraphVault.ts
@@ -1,0 +1,6 @@
+import { VaultByIdQuery } from './generated/graphql/inKindSubgraph';
+
+export type SubgraphVault = Omit<
+  NonNullable<VaultByIdQuery['vault']>,
+  'controller'
+>;


### PR DESCRIPTION
Broken out of #405, we need to take the whole vault here for use in the tooltip later. Just removing some noise from the diff.