### PR TITLE
refactor: useTarget can return data from yesterday

### DIFF
--- a/__tests__/components/ContractStatus.test.tsx
+++ b/__tests__/components/ContractStatus.test.tsx
@@ -80,7 +80,7 @@ describe('ContractStatus', () => {
       pricesDataPositive.markValues[0].value,
     );
     mockedUseTarget.mockReturnValue({
-      newTarget: ethers.utils.parseUnits(
+      target: ethers.utils.parseUnits(
         pricesDataPositive.targetValues[1].value.toString(),
         18,
       ),
@@ -101,7 +101,7 @@ describe('ContractStatus', () => {
       pricesDataNegative.markValues[0].value,
     );
     mockedUseTarget.mockReturnValue({
-      newTarget: ethers.utils.parseUnits(
+      target: ethers.utils.parseUnits(
         pricesDataNegative.targetValues[1].value.toString(),
         18,
       ),

--- a/components/ContractStatus/ContractStatus.tsx
+++ b/components/ContractStatus/ContractStatus.tsx
@@ -26,7 +26,7 @@ export function ContractStatus() {
       return null;
     }
     return parseFloat(
-      ethers.utils.formatUnits(newTargetResult.newTarget, underlying.decimals),
+      ethers.utils.formatUnits(newTargetResult.target, underlying.decimals),
     );
   }, [newTargetResult, underlying.decimals]);
 

--- a/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.tsx
+++ b/components/Controllers/OpenVault/VaultDebtPicker/VaultDebtPicker.tsx
@@ -356,7 +356,7 @@ export function VaultDebtPicker({
       newPrice,
       parseFloat(
         ethers.utils.formatUnits(
-          ethers.BigNumber.from(target.newTarget),
+          ethers.BigNumber.from(target.target),
           paprController.underlying.decimals,
         ),
       ),

--- a/components/SwapPageContent/ImpactProjection.tsx
+++ b/components/SwapPageContent/ImpactProjection.tsx
@@ -80,7 +80,7 @@ function ImpactProjectionLoaded({
 
   const newTargetNumber = useMemo(() => {
     return parseFloat(
-      ethers.utils.formatUnits(newTargetUpdate.newTarget, underlying.decimals),
+      ethers.utils.formatUnits(newTargetUpdate.target, underlying.decimals),
     );
   }, [newTargetUpdate, underlying.decimals]);
 

--- a/hooks/useControllerPricesData/useControllerPricesData.ts
+++ b/hooks/useControllerPricesData/useControllerPricesData.ts
@@ -152,7 +152,7 @@ function targets(
 
   // get what target would be if updated at this moment and add to array
   if (sortedTargets.length > 0) {
-    const { newTarget, timestamp } = targetUpdate;
+    const { target: newTarget, timestamp } = targetUpdate;
     sortedTargets.push({
       id: 'filler',
       newTarget,

--- a/hooks/useMaxDebt/useMaxDebt.ts
+++ b/hooks/useMaxDebt/useMaxDebt.ts
@@ -27,7 +27,7 @@ export function useMaxDebt(
   collateral: string | string[],
   oraclePriceType: OraclePriceType,
 ): BigNumber | null {
-  const target = useTarget();
+  const targetResult = useTarget();
   const oracleInfo = useOracleInfo(oraclePriceType);
   const {
     underlying: { decimals },
@@ -35,7 +35,7 @@ export function useMaxDebt(
   } = useController();
 
   const result = useMemo(() => {
-    if (!oracleInfo || !target) {
+    if (!oracleInfo || !targetResult) {
       return null;
     }
 
@@ -46,7 +46,7 @@ export function useMaxDebt(
       return maxDebt(
         parseUnits(oracleInfo[collateral].price.toString(), decimals),
         maxLTV,
-        target.newTarget,
+        targetResult.target,
       );
     }
 
@@ -54,12 +54,12 @@ export function useMaxDebt(
       maxDebt(
         parseUnits(oracleInfo[asset].price.toString(), decimals),
         maxLTV,
-        target.newTarget,
+        targetResult.target,
       ),
     );
 
     return totalDebtPerCollateral.reduce((a, b) => a.add(b), BigNumber.from(0));
-  }, [collateral, decimals, maxLTV, oracleInfo, target]);
+  }, [collateral, decimals, maxLTV, oracleInfo, targetResult]);
 
   return result;
 }

--- a/pages/tokens/[token]/test.tsx
+++ b/pages/tokens/[token]/test.tsx
@@ -1,7 +1,7 @@
 import { captureException } from '@sentry/nextjs';
 import { TestPageContent } from 'components/Controllers/TestPageContent';
 import { ControllerContextProvider, PaprController } from 'hooks/useController';
-import { configs, getConfig, SupportedToken } from 'lib/config';
+import { configProxy, SupportedToken } from 'lib/config';
 import { fetchSubgraphData } from 'lib/PaprController';
 import { GetServerSideProps } from 'next';
 
@@ -12,19 +12,19 @@ export type TestProps = {
 export const getServerSideProps: GetServerSideProps<TestProps> = async (
   context,
 ) => {
-  const token = context.params?.token as SupportedToken;
-  const address: string | undefined =
-    getConfig(token)?.controllerAddress?.toLocaleLowerCase();
-  if (!address) {
+  const token = context.params?.token as string;
+  const config = configProxy[token];
+  if (!config) {
     return {
       notFound: true,
     };
   }
+  const address = config.controllerAddress.toLocaleLowerCase();
 
   const controllerSubgraphData = await fetchSubgraphData(
     address,
-    configs[token].uniswapSubgraph,
-    token,
+    config.uniswapSubgraph,
+    token as SupportedToken,
   );
 
   if (!controllerSubgraphData) {


### PR DESCRIPTION
For some of the tooltips in #405 we need to know the target from a day ago. Splitting this out so that only the core code appears in the main PR.

Additionally, found an error in `test.tsx` where we were still using the old method of looking up the config. This fixes that error.