### PR TITLE
[NFT-1005] fix: don't show loans with no collateral

### DIFF
--- a/components/Controllers/Loans/Loans.tsx
+++ b/components/Controllers/Loans/Loans.tsx
@@ -23,7 +23,8 @@ export function Loans() {
   const { pricesData } = useControllerPricesData();
   const paprController = useController();
   const currentVaults = useMemo(
-    () => paprController.vaults?.filter((v) => v.debt > 0),
+    () =>
+      paprController.vaults?.filter((v) => v.debt > 0 && v.collateralCount > 0),
     [paprController],
   );
   const oracleInfo = useOracleInfo(OraclePriceType.twap);


### PR DESCRIPTION
There's a case where a loan can be without collateral (only NFT is up for auction). In that case, we want to filter it from the list. This solves the runtime error that came up today.