### PR TITLE
NFT-1034: Refactor uniswap quote fetching + VaultDebtPicker

### DIFF
--- a/components/Controllers/ApproveButtons/ApproveNFTButton.tsx
+++ b/components/Controllers/ApproveButtons/ApproveNFTButton.tsx
@@ -1,6 +1,6 @@
 import { TransactionButton } from 'components/Button';
-import { useAsyncValue } from 'hooks/useAsyncValue';
 import { useController } from 'hooks/useController';
+import { useNFTSymbol } from 'hooks/useNFTSymbol';
 import { useSignerOrProvider } from 'hooks/useSignerOrProvider';
 import { pirsch } from 'lib/pirsch';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -14,13 +14,11 @@ import {
 
 type ApproveNFTButtonProps = {
   collateralContractAddress: string;
-  approved: boolean;
   setApproved: (val: boolean) => void;
 };
 
 export function ApproveNFTButton({
   collateralContractAddress,
-  approved,
   setApproved,
 }: ApproveNFTButtonProps) {
   const paprController = useController();
@@ -47,10 +45,8 @@ export function ApproveNFTButton({
     initializeApproved();
   }, [initializeApproved]);
 
-  const symbol = useAsyncValue(
-    () => collateralContract.symbol(),
-    [collateralContract],
-  );
+  const symbol = useNFTSymbol(collateralContractAddress);
+
   const { config } = usePrepareContractWrite({
     address: collateralContract.address as `0x${string}`,
     abi: erc721ABI,

--- a/components/Controllers/OpenVault/AmountToBorrowOrRepayInput.tsx
+++ b/components/Controllers/OpenVault/AmountToBorrowOrRepayInput.tsx
@@ -1,0 +1,87 @@
+import { ethers } from 'ethers';
+import { useController } from 'hooks/useController';
+import { formatBigNum } from 'lib/numberFormat';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Input } from 'reakit';
+
+import styles from './VaultDebtPicker.module.css';
+
+type AmountToBorrowOrRepayInputProps = {
+  isBorrowing: boolean;
+  currentVaultDebt: ethers.BigNumber;
+  debtToBorrowOrRepay: ethers.BigNumber;
+  setControlledSliderValue: (val: number) => void;
+  setChosenDebt: (val: ethers.BigNumber) => void;
+};
+
+export function AmountToBorrowOrRepayInput({
+  isBorrowing,
+  currentVaultDebt,
+  debtToBorrowOrRepay,
+  setControlledSliderValue,
+  setChosenDebt,
+}: AmountToBorrowOrRepayInputProps) {
+  const paprController = useController();
+  const decimals = useMemo(
+    () => paprController.paprToken.decimals,
+    [paprController.paprToken.decimals],
+  );
+
+  const [amount, setAmount] = useState<string>(
+    ethers.utils.formatUnits(debtToBorrowOrRepay, decimals),
+  );
+  const [editingInput, setEditingInput] = useState<boolean>(false);
+
+  const inputValue = useMemo(() => {
+    if (editingInput) return amount;
+    const amountBigNumber = amount
+      ? ethers.utils.parseUnits(amount, decimals)
+      : ethers.BigNumber.from(0);
+    return formatBigNum(amountBigNumber, decimals);
+  }, [amount, decimals, editingInput]);
+
+  const handleInputValueChanged = useCallback(
+    async (val: string) => {
+      setAmount(val);
+      if (!val || isNaN(parseFloat(val)) || parseFloat(val) < 0) return; // do not change slider if input is invalid
+
+      const debtDelta: ethers.BigNumber = ethers.utils.parseUnits(
+        val,
+        decimals,
+      );
+
+      const newDebt = isBorrowing
+        ? currentVaultDebt.add(debtDelta)
+        : currentVaultDebt.sub(debtDelta);
+      const formattedNewDebt = formatBigNum(newDebt, decimals);
+
+      setChosenDebt(newDebt);
+      setControlledSliderValue(parseFloat(formattedNewDebt));
+    },
+    [
+      decimals,
+      setChosenDebt,
+      setControlledSliderValue,
+      isBorrowing,
+      currentVaultDebt,
+    ],
+  );
+
+  useEffect(() => {
+    if (!editingInput) {
+      setAmount(formatBigNum(debtToBorrowOrRepay, decimals));
+    }
+  }, [debtToBorrowOrRepay, decimals, editingInput]);
+
+  return (
+    <span className={styles.debtAmountInputWrapper}>
+      <Input
+        value={`${inputValue}`}
+        type="number"
+        onChange={(e) => handleInputValueChanged(e.target.value)}
+        onFocus={() => setEditingInput(true)}
+        onBlur={() => setEditingInput(false)}
+      />
+    </span>
+  );
+}

--- a/components/Controllers/OpenVault/AmountToBorrowOrRepayInput.tsx
+++ b/components/Controllers/OpenVault/AmountToBorrowOrRepayInput.tsx
@@ -4,7 +4,7 @@ import { formatBigNum } from 'lib/numberFormat';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Input } from 'reakit';
 
-import styles from './VaultDebtPicker.module.css';
+import styles from './VaultDebtPicker/VaultDebtPicker.module.css';
 
 type AmountToBorrowOrRepayInputProps = {
   isBorrowing: boolean;

--- a/components/Controllers/OpenVault/LoanActionSummary.tsx
+++ b/components/Controllers/OpenVault/LoanActionSummary.tsx
@@ -1,0 +1,137 @@
+import { ethers } from 'ethers';
+import { useController } from 'hooks/useController';
+import { useTheme } from 'hooks/useTheme';
+import { formatBigNum, formatPercent } from 'lib/numberFormat';
+import { useMemo } from 'react';
+
+import styles from './VaultDebtPicker.module.css';
+
+type LoanActionSummaryProps = {
+  isBorrowing: boolean;
+  usingPerpetual: boolean;
+  debtToBorrowOrRepay: ethers.BigNumber;
+  quote: ethers.BigNumber | null;
+  fee: ethers.BigNumber | null;
+  slippage: number | null;
+  projectedAPR: number | null;
+  setUsingPerpetual: (val: boolean) => void;
+  errorMessage: string;
+};
+
+export function LoanActionSummary({
+  isBorrowing,
+  usingPerpetual,
+  debtToBorrowOrRepay,
+  quote,
+  fee,
+  slippage,
+  projectedAPR,
+  setUsingPerpetual,
+  errorMessage,
+}: LoanActionSummaryProps) {
+  const controller = useController();
+  const theme = useTheme();
+
+  const quoteWithFee = useMemo(() => {
+    if (!quote || !fee) return null;
+    if (isBorrowing) return quote.sub(fee);
+    else return quote.add(fee);
+  }, [quote, fee, isBorrowing]);
+
+  return (
+    <div className={styles.loanActionSummaryWrapper}>
+      <div className={[styles.loanActionSummary, styles[theme]].join(' ')}>
+        <div>
+          <div>
+            <p>
+              {isBorrowing ? 'Borrow' : 'Repay'} {controller.paprToken.symbol}
+            </p>
+          </div>
+          <div>
+            <p>
+              {formatBigNum(debtToBorrowOrRepay, controller.paprToken.decimals)}
+            </p>
+          </div>
+        </div>
+        <div>
+          <div className={styles.swapQuote}>
+            <input
+              type="checkbox"
+              onChange={() => setUsingPerpetual(!usingPerpetual)}
+            />
+            {isBorrowing && <p>Swap for {controller.underlying.symbol}</p>}
+            {!isBorrowing && <p>Swap from {controller.underlying.symbol}</p>}
+          </div>
+          <div>
+            {quote && (
+              <p
+                className={`${
+                  usingPerpetual ? [styles.greyed, styles[theme]].join(' ') : ''
+                }`}>
+                {formatBigNum(quote, controller.underlying.decimals)}
+              </p>
+            )}
+            {!quote && <p>...</p>}
+          </div>
+        </div>
+        <div
+          className={`${
+            usingPerpetual ? [styles.greyed, styles[theme]].join(' ') : ''
+          }`}>
+          <div>
+            <p>Slippage</p>
+          </div>
+          <div>
+            {slippage !== null && <p>{slippage.toFixed(2)}%</p>}
+            {slippage === null && <p>...</p>}
+          </div>
+        </div>
+        <div
+          className={`${
+            usingPerpetual ? [styles.greyed, styles[theme]].join(' ') : ''
+          }`}>
+          <div>
+            <p>papr.wtf swap fee (0.3%)</p>
+          </div>
+          <div>
+            {fee && <p>{formatBigNum(fee, controller.underlying.decimals)}</p>}
+            {!fee && <p>-</p>}
+          </div>
+        </div>
+        <div
+          className={`${
+            usingPerpetual ? [styles.greyed, styles[theme]].join(' ') : ''
+          }`}>
+          <div>
+            <p>Projected Contract Rate</p>
+          </div>
+          <div>
+            {projectedAPR && <p>{formatPercent(projectedAPR)}</p>}
+            {!projectedAPR && <p>-</p>}
+          </div>
+        </div>
+        <div>
+          <div>
+            <p>
+              {isBorrowing ? 'Receive' : 'Pay'}{' '}
+              {usingPerpetual
+                ? controller.paprToken.symbol
+                : controller.underlying.symbol}
+            </p>
+          </div>
+          <div>
+            {usingPerpetual
+              ? formatBigNum(debtToBorrowOrRepay, controller.paprToken.decimals)
+              : quoteWithFee &&
+                formatBigNum(quoteWithFee, controller.underlying.decimals)}
+          </div>
+        </div>
+        {!!errorMessage && (
+          <div className={styles.error}>
+            <p>{errorMessage}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/Controllers/OpenVault/LoanActionSummary.tsx
+++ b/components/Controllers/OpenVault/LoanActionSummary.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'hooks/useTheme';
 import { formatBigNum, formatPercent } from 'lib/numberFormat';
 import { useMemo } from 'react';
 
-import styles from './VaultDebtPicker.module.css';
+import styles from './VaultDebtPicker/VaultDebtPicker.module.css';
 
 type LoanActionSummaryProps = {
   isBorrowing: boolean;

--- a/components/Controllers/OpenVault/VaultWriteButton.tsx
+++ b/components/Controllers/OpenVault/VaultWriteButton.tsx
@@ -180,7 +180,6 @@ export function VaultWriteButton({
       {!usingSafeTransferFrom && depositNFTs.length > 0 && (
         <ApproveNFTButton
           collateralContractAddress={collateralContractAddress}
-          approved={collateralApproved}
           setApproved={setCollateralApproved}
         />
       )}

--- a/hooks/useNFTSymbol/index.ts
+++ b/hooks/useNFTSymbol/index.ts
@@ -1,0 +1,1 @@
+export { useNFTSymbol } from './useNFTSymbol';

--- a/hooks/useNFTSymbol/useNFTSymbol.ts
+++ b/hooks/useNFTSymbol/useNFTSymbol.ts
@@ -1,0 +1,15 @@
+import { getAddress } from 'ethers/lib/utils.js';
+import { useController } from 'hooks/useController';
+import { useMemo } from 'react';
+
+export function useNFTSymbol(contractAddress: string) {
+  const { allowedCollateral } = useController();
+  const nftSymbol = useMemo(
+    () =>
+      allowedCollateral.find(
+        (ac) => getAddress(ac.token.id) === getAddress(contractAddress),
+      )?.token.symbol || '',
+    [allowedCollateral, contractAddress],
+  );
+  return nftSymbol;
+}

--- a/hooks/usePoolQuote/index.ts
+++ b/hooks/usePoolQuote/index.ts
@@ -1,0 +1,1 @@
+export { usePoolQuote } from './usePoolQuote';

--- a/hooks/usePoolQuote/usePoolQuote.ts
+++ b/hooks/usePoolQuote/usePoolQuote.ts
@@ -1,0 +1,44 @@
+import { ethers } from 'ethers';
+import { useConfig } from 'hooks/useConfig';
+import { SupportedToken } from 'lib/config';
+import { emptyQuoteResult, QuoterResult } from 'lib/controllers';
+import { getQuoteForSwap, getQuoteForSwapOutput } from 'lib/controllers';
+import { useEffect, useState } from 'react';
+
+export type QuoteWithSlippage = QuoterResult & { slippage: number };
+
+export function usePoolQuote(
+  amount: ethers.BigNumber | undefined,
+  inputToken: string,
+  outputToken: string,
+  tradeType: 'exactIn' | 'exactOut',
+  skip = false,
+) {
+  const { tokenName } = useConfig();
+  const [quoteResult, setQuoteResult] =
+    useState<QuoterResult>(emptyQuoteResult);
+
+  useEffect(() => {
+    const fetchQuote = async () => {
+      if (!amount) return emptyQuoteResult;
+      if (tradeType === 'exactIn') {
+        return getQuoteForSwap(
+          amount,
+          inputToken,
+          outputToken,
+          tokenName as SupportedToken,
+        );
+      } else {
+        return getQuoteForSwapOutput(
+          amount,
+          inputToken,
+          outputToken,
+          tokenName as SupportedToken,
+        );
+      }
+    };
+    if (!skip) fetchQuote().then((quote) => setQuoteResult(quote));
+  }, [amount, inputToken, outputToken, tradeType, tokenName, skip]);
+
+  return quoteResult;
+}

--- a/hooks/usePoolQuote/usePoolQuote.ts
+++ b/hooks/usePoolQuote/usePoolQuote.ts
@@ -1,44 +1,92 @@
 import { ethers } from 'ethers';
 import { useConfig } from 'hooks/useConfig';
 import { SupportedToken } from 'lib/config';
-import { emptyQuoteResult, QuoterResult } from 'lib/controllers';
+import {
+  computeSlippageForSwap,
+  emptyQuoteResult,
+  ERC20Token,
+  QuoterResult,
+} from 'lib/controllers';
 import { getQuoteForSwap, getQuoteForSwapOutput } from 'lib/controllers';
 import { useEffect, useState } from 'react';
 
-export type QuoteWithSlippage = QuoterResult & { slippage: number };
+export type QuoteWithSlippage = QuoterResult & { slippage: number | null };
+const emptyQuoteWithSlippage: QuoteWithSlippage = {
+  ...emptyQuoteResult,
+  slippage: null,
+};
 
-export function usePoolQuote(
-  amount: ethers.BigNumber | undefined,
-  inputToken: string,
-  outputToken: string,
-  tradeType: 'exactIn' | 'exactOut',
-  skip = false,
-) {
+type UsePoolQuoteParams = {
+  amount: ethers.BigNumber | undefined;
+  inputToken: ERC20Token;
+  outputToken: ERC20Token;
+  tradeType: 'exactIn' | 'exactOut';
+  withSlippage?: boolean;
+  skip?: boolean;
+};
+
+export function usePoolQuote({
+  amount,
+  inputToken,
+  outputToken,
+  tradeType,
+  withSlippage,
+  skip,
+}: UsePoolQuoteParams) {
   const { tokenName } = useConfig();
-  const [quoteResult, setQuoteResult] =
-    useState<QuoterResult>(emptyQuoteResult);
+  const [quoteResult, setQuoteResult] = useState<QuoteWithSlippage>(
+    emptyQuoteWithSlippage,
+  );
 
   useEffect(() => {
     const fetchQuote = async () => {
-      if (!amount) return emptyQuoteResult;
+      if (!amount) return emptyQuoteWithSlippage;
+
+      const quoteWithSlippage: QuoteWithSlippage = {
+        ...emptyQuoteWithSlippage,
+      };
+      let quoterResult: QuoterResult;
+
       if (tradeType === 'exactIn') {
-        return getQuoteForSwap(
+        quoterResult = await getQuoteForSwap(
           amount,
-          inputToken,
-          outputToken,
+          inputToken.id,
+          outputToken.id,
           tokenName as SupportedToken,
         );
       } else {
-        return getQuoteForSwapOutput(
+        quoterResult = await getQuoteForSwapOutput(
           amount,
-          inputToken,
-          outputToken,
+          inputToken.id,
+          outputToken.id,
           tokenName as SupportedToken,
         );
       }
+      if (!quoterResult.quote) return quoteWithSlippage;
+
+      quoteWithSlippage.quote = quoterResult.quote;
+      quoteWithSlippage.sqrtPriceX96After = quoterResult.sqrtPriceX96After;
+      if (withSlippage)
+        quoteWithSlippage.slippage = await computeSlippageForSwap(
+          quoterResult.quote,
+          inputToken,
+          outputToken,
+          amount,
+          tradeType,
+          tokenName as SupportedToken,
+        );
+      return quoteWithSlippage;
     };
     if (!skip) fetchQuote().then((quote) => setQuoteResult(quote));
-  }, [amount, inputToken, outputToken, tradeType, tokenName, skip]);
+  }, [
+    amount,
+    inputToken,
+    outputToken,
+    tradeType,
+    tokenName,
+    withSlippage,
+    skip,
+  ]);
 
   return quoteResult;
 }

--- a/hooks/useVaultComponentNFTs/index.ts
+++ b/hooks/useVaultComponentNFTs/index.ts
@@ -1,0 +1,1 @@
+export { useVaultComponentNFTs } from './useVaultComponentNFTs';

--- a/hooks/useVaultComponentNFTs/useVaultComponentNFTs.tsx
+++ b/hooks/useVaultComponentNFTs/useVaultComponentNFTs.tsx
@@ -1,0 +1,69 @@
+import { getAddress } from 'ethers/lib/utils.js';
+import { AccountNFTsResponse } from 'hooks/useAccountNFTs';
+import { useMemo } from 'react';
+import {
+  AuctionsByNftOwnerAndCollectionDocument,
+  AuctionsByNftOwnerAndCollectionQuery,
+} from 'types/generated/graphql/inKindSubgraph';
+import { SubgraphVault } from 'types/SubgraphVault';
+import { useQuery } from 'urql';
+import { useAccount } from 'wagmi';
+
+// returns all the NFTs we would want to display on the vault debt picker
+// this includes all the all the NFTs in the user's wallet, all the NFTs in the vault, and all the NFTs that are in auction/been auctioned
+export function useVaultComponentNFTs(
+  collateralContractAddress: string,
+  userNFTsForVault: AccountNFTsResponse[],
+  vault: SubgraphVault | undefined,
+) {
+  const { address } = useAccount();
+  const [{ data: auctionsByNftOwnerAndCollection }] =
+    useQuery<AuctionsByNftOwnerAndCollectionQuery>({
+      query: AuctionsByNftOwnerAndCollectionDocument,
+      variables: {
+        nftOwner: address!,
+        collection: collateralContractAddress.toLowerCase(),
+      },
+    });
+
+  const userAndVaultNFTs = useMemo(() => {
+    return (vault?.collateral || [])
+      .map((c) => ({
+        address: vault?.token.id,
+        tokenId: c.tokenId,
+        inVault: true,
+        isLiquidating: false,
+        isLiquidated: false,
+      }))
+      .concat(
+        (auctionsByNftOwnerAndCollection?.auctions || []).map((a) => ({
+          address: a.auctionAssetContract.id,
+          tokenId: a.auctionAssetID,
+          inVault: false,
+          isLiquidating: !a.endPrice,
+          isLiquidated: !!a.endPrice,
+        })),
+      )
+      .concat(
+        userNFTsForVault
+          .filter(
+            // filter out nfts that are already in the vault, major assumption here is goldsky is faster than thegraph
+            (nft) =>
+              vault?.collateral.find(
+                (c) =>
+                  getAddress(vault.token.id) === getAddress(nft.address) &&
+                  c.tokenId === nft.tokenId,
+              ) === undefined,
+          )
+          .map((nft) => ({
+            address: nft.address,
+            tokenId: nft.tokenId,
+            inVault: false,
+            isLiquidating: false,
+            isLiquidated: false,
+          })),
+      );
+  }, [userNFTsForVault, vault, auctionsByNftOwnerAndCollection?.auctions]);
+
+  return userAndVaultNFTs;
+}

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -199,13 +199,13 @@ export async function computeSlippageForSwap(
   tokenIn: ERC20Token,
   tokenOut: ERC20Token,
   amount: ethers.BigNumber,
-  useExactInput: boolean,
+  tradeType: 'exactIn' | 'exactOut',
   tokenName: SupportedToken,
 ) {
   const withoutSlippageAmount = ethers.BigNumber.from('10000000');
   const quoter = Quoter(configs[tokenName].jsonRpcProvider, tokenName);
   let quoteWithoutSlippage: ethers.BigNumber;
-  if (useExactInput) {
+  if (tradeType === 'exactIn') {
     ({ amountOut: quoteWithoutSlippage } =
       await quoter.callStatic.quoteExactInputSingle({
         tokenIn: tokenIn.id,
@@ -229,7 +229,7 @@ export async function computeSlippageForSwap(
     ethers.utils.formatUnits(
       quoteWithSlippage,
       ethers.BigNumber.from(
-        useExactInput ? tokenOut.decimals : tokenIn.decimals,
+        tradeType === 'exactIn' ? tokenOut.decimals : tokenIn.decimals,
       ),
     ),
   );
@@ -237,7 +237,7 @@ export async function computeSlippageForSwap(
     ethers.utils.formatUnits(
       quoteWithoutSlippage,
       ethers.BigNumber.from(
-        useExactInput ? tokenOut.decimals : tokenIn.decimals,
+        tradeType === 'exactIn' ? tokenOut.decimals : tokenIn.decimals,
       ),
     ),
   );


### PR DESCRIPTION
This PR refactors a lot of the `VaultDebtPicker` component. Breaking it down into smaller chunks, and removing all usages of `useAsyncValue`. There is a new robust `usePoolQuote` hook that handles fetching quotes based on an amount and trade type, that is used throughout the component now