### PR TITLE
fix: ensure we use latest block timestamp when passing price to contract

### DIFF
--- a/__tests__/hooks/useOracleSynced.test.ts
+++ b/__tests__/hooks/useOracleSynced.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useOracleSynced } from 'hooks/useOracleSynced';
-import { getLatestBlockTimestamp } from 'lib/chainHelpers';
+import { useTimestamp } from 'hooks/useTimestamp';
 import { OraclePriceType } from 'lib/oracle/reservoir';
 
 jest.mock('hooks/useOracleInfo/useOracleInfo', () => ({
@@ -20,39 +20,40 @@ jest.mock('hooks/useOracleInfo/useOracleInfo', () => ({
   }),
 }));
 
-jest.mock('lib/chainHelpers', () => ({
-  getLatestBlockTimestamp: jest.fn(),
+jest.mock('hooks/useTimestamp', () => ({
+  useTimestamp: jest.fn(),
 }));
 
-const mockedGetLatestBlockTimestamp =
-  getLatestBlockTimestamp as jest.MockedFunction<
-    typeof getLatestBlockTimestamp
-  >;
+const mockUseTimestamp = useTimestamp as jest.MockedFunction<
+  typeof useTimestamp
+>;
 
 describe('useOracleSync', () => {
   it('returns true when oracle message is older than latest block timestamp', async () => {
-    mockedGetLatestBlockTimestamp.mockResolvedValue(1001);
-    const { result, waitForNextUpdate } = renderHook(() =>
+    mockUseTimestamp.mockReturnValue({
+      blockNumber: 0,
+      timestamp: 1001,
+    });
+    const { result } = renderHook(() =>
       useOracleSynced(
         '0x36b8f7b7be4680c3511e764e0d2b56d54ad57d6e',
         OraclePriceType.lower,
       ),
     );
-    expect(result.current).toBe(false);
-    await waitForNextUpdate();
     expect(result.current).toBe(true);
   });
 
   it('returns false when oracle message is newer than latest block timestamp', async () => {
-    mockedGetLatestBlockTimestamp.mockResolvedValue(999);
-    const { result, waitForNextUpdate } = renderHook(() =>
+    mockUseTimestamp.mockReturnValue({
+      blockNumber: 0,
+      timestamp: 999,
+    });
+    const { result } = renderHook(() =>
       useOracleSynced(
         '0x36b8f7b7be4680c3511e764e0d2b56d54ad57d6e',
         OraclePriceType.lower,
       ),
     );
-    expect(result.current).toBe(false);
-    await waitForNextUpdate();
     expect(result.current).toBe(false);
   });
 });

--- a/__tests__/lib/auctions.test.ts
+++ b/__tests__/lib/auctions.test.ts
@@ -1,11 +1,19 @@
 import { ethers } from 'ethers';
-import { currentPrice } from 'lib/auctions';
-import { ONE } from 'lib/constants';
-import { convertOneScaledValue } from 'lib/controllers';
+import { AuctionType, currentPrice } from 'lib/auctions';
 
+const startTimestamp = 10_000;
 const oneDayInSeconds = 60 * 60 * 24;
 const startPrice = ethers.BigNumber.from(10).pow(18);
-const perPeriodDecayPercentWad = convertOneScaledValue(ONE.mul(9).div(10), 8);
+const perPeriodDecayPercentWad = ethers.BigNumber.from('900000000000000000');
+
+const mockAuction: Partial<AuctionType> = {
+  start: {
+    timestamp: startTimestamp,
+  },
+  perPeriodDecayPercentWad,
+  startPrice,
+  secondsInPeriod: oneDayInSeconds,
+};
 
 export function approximatelyEquals(
   n1: ethers.BigNumber,
@@ -25,12 +33,8 @@ describe('auction library', () => {
       [4, ethers.BigNumber.from(10).pow(14)],
       [10, ethers.BigNumber.from(10).pow(8)],
     ])('after %d days', (numDays, expected) => {
-      const result = currentPrice(
-        startPrice,
-        numDays * oneDayInSeconds,
-        oneDayInSeconds,
-        perPeriodDecayPercentWad,
-      );
+      const timestamp = numDays * oneDayInSeconds + startTimestamp;
+      const result = currentPrice(mockAuction as AuctionType, timestamp);
       expect(approximatelyEquals(result, expected)).toBeTruthy();
     });
   });

--- a/components/Controllers/AuctionPageContent/AuctionGraph.tsx
+++ b/components/Controllers/AuctionPageContent/AuctionGraph.tsx
@@ -3,7 +3,6 @@ import { Context } from 'chartjs-plugin-datalabels';
 import { ethers } from 'ethers';
 import { useController } from 'hooks/useController';
 import { currentPrice } from 'lib/auctions';
-import { convertOneScaledValue } from 'lib/controllers';
 import { formatBigNum } from 'lib/numberFormat';
 import { useMemo } from 'react';
 import { Line } from 'react-chartjs-2';
@@ -20,7 +19,6 @@ export function generateTimestampsAndPrices(
   const chartY: number[] = [];
   const startTime = auction.start.timestamp;
   const endTime = startTime + 86400 * 3;
-  const startPrice = ethers.BigNumber.from(auction.startPrice);
 
   for (
     let t = startTime;
@@ -29,20 +27,8 @@ export function generateTimestampsAndPrices(
   ) {
     chartX.push(t);
     chartY.push(
-      parseFloat(
-        formatBigNum(
-          currentPrice(
-            startPrice,
-            t - startTime,
-            parseInt(auction.secondsInPeriod),
-            convertOneScaledValue(
-              ethers.BigNumber.from(auction.perPeriodDecayPercentWad),
-              4,
-            ),
-          ),
-          18,
-        ),
-      ) * latestUniswapPrice,
+      parseFloat(formatBigNum(currentPrice(auction, t), 18)) *
+        latestUniswapPrice,
     );
   }
   return [chartX, chartY];

--- a/components/YourPositions/YourPositions.tsx
+++ b/components/YourPositions/YourPositions.tsx
@@ -180,15 +180,13 @@ export function YourPositions({ onPerformancePage }: YourPositionsProps) {
             </tr>
           </thead>
           <tbody>
-            {currentVaults
-              .filter((v) => v.collateralCount > 0)
-              .map((vault) => (
-                <VaultOverview
-                  vaultInfo={vault}
-                  key={vault.id}
-                  ethUSDPrice={ethUSDPrice}
-                />
-              ))}
+            {currentVaults.map((vault) => (
+              <VaultOverview
+                vaultInfo={vault}
+                key={vault.id}
+                ethUSDPrice={ethUSDPrice}
+              />
+            ))}
           </tbody>
         </Table>
       )}

--- a/components/YourPositions/YourPositions.tsx
+++ b/components/YourPositions/YourPositions.tsx
@@ -180,13 +180,15 @@ export function YourPositions({ onPerformancePage }: YourPositionsProps) {
             </tr>
           </thead>
           <tbody>
-            {currentVaults.map((vault) => (
-              <VaultOverview
-                vaultInfo={vault}
-                key={vault.id}
-                ethUSDPrice={ethUSDPrice}
-              />
-            ))}
+            {currentVaults
+              .filter((v) => v.collateralCount > 0)
+              .map((vault) => (
+                <VaultOverview
+                  vaultInfo={vault}
+                  key={vault.id}
+                  ethUSDPrice={ethUSDPrice}
+                />
+              ))}
           </tbody>
         </Table>
       )}

--- a/hooks/useOracleSynced/useOracleSynced.ts
+++ b/hooks/useOracleSynced/useOracleSynced.ts
@@ -1,6 +1,5 @@
-import { useConfig } from 'hooks/useConfig';
 import { useOracleInfo } from 'hooks/useOracleInfo/useOracleInfo';
-import { getLatestBlockTimestamp } from 'lib/chainHelpers';
+import { useTimestamp } from 'hooks/useTimestamp';
 import { OraclePriceType } from 'lib/oracle/reservoir';
 import { useEffect, useState } from 'react';
 
@@ -9,27 +8,15 @@ export function useOracleSynced(
   oracleKind: OraclePriceType,
 ) {
   const oracleInfo = useOracleInfo(oracleKind);
-  const { jsonRpcProvider } = useConfig();
 
   const [synced, setSynced] = useState<boolean>(false);
-  const [blockTimestamp, setBlockTimestamp] = useState<number>(0);
-
-  useEffect(() => {
-    const fetchBlockTimestamp = async () => {
-      const blockTimestamp = await getLatestBlockTimestamp(jsonRpcProvider);
-      setBlockTimestamp(blockTimestamp);
-    };
-
-    fetchBlockTimestamp();
-    setInterval(() => {
-      fetchBlockTimestamp();
-    }, 1000);
-  }, [oracleInfo, jsonRpcProvider]);
+  const blockTimestamp = useTimestamp();
 
   useEffect(() => {
     if (!blockTimestamp || !oracleInfo) return;
     if (
-      blockTimestamp >= oracleInfo[collateralContractAddress].message.timestamp
+      blockTimestamp.timestamp >=
+      oracleInfo[collateralContractAddress].message.timestamp
     ) {
       setSynced(true);
     }

--- a/lib/auctions.ts
+++ b/lib/auctions.ts
@@ -5,7 +5,7 @@ import { convertOneScaledValue } from './controllers';
 
 export type AuctionType = NonNullable<AuctionQuery['auction']>;
 
-export function currentPrice(auction: AuctionType, timestamp: number) {
+export function currentPrice(auction: AuctionType, currentTimestamp: number) {
   const startPrice = ethers.BigNumber.from(auction.startPrice);
   const secondsInPeriod = parseInt(auction.secondsInPeriod);
   const perPeriodDecayPercent = convertOneScaledValue(
@@ -13,7 +13,7 @@ export function currentPrice(auction: AuctionType, timestamp: number) {
     4,
   );
 
-  const secondsElapsed = timestamp - auction.start.timestamp;
+  const secondsElapsed = currentTimestamp - auction.start.timestamp;
   const ratio = secondsElapsed / secondsInPeriod;
   const percentRemainingPerPeriod = 1 - perPeriodDecayPercent;
   const m = Math.pow(percentRemainingPerPeriod, ratio);

--- a/lib/auctions.ts
+++ b/lib/auctions.ts
@@ -1,11 +1,19 @@
 import { ethers } from 'ethers';
+import { AuctionQuery } from 'types/generated/graphql/inKindSubgraph';
 
-export function currentPrice(
-  startPrice: ethers.BigNumber,
-  secondsElapsed: number,
-  secondsInPeriod: number,
-  perPeriodDecayPercent: number,
-) {
+import { convertOneScaledValue } from './controllers';
+
+export type AuctionType = NonNullable<AuctionQuery['auction']>;
+
+export function currentPrice(auction: AuctionType, timestamp: number) {
+  const startPrice = ethers.BigNumber.from(auction.startPrice);
+  const secondsInPeriod = parseInt(auction.secondsInPeriod);
+  const perPeriodDecayPercent = convertOneScaledValue(
+    ethers.BigNumber.from(auction.perPeriodDecayPercentWad),
+    4,
+  );
+
+  const secondsElapsed = timestamp - auction.start.timestamp;
   const ratio = secondsElapsed / secondsInPeriod;
   const percentRemainingPerPeriod = 1 - perPeriodDecayPercent;
   const m = Math.pow(percentRemainingPerPeriod, ratio);


### PR DESCRIPTION
Previously, we were using the live client timestamp (i.e. `now()`) and using that to compute the auction `maxPrice` that we'd send to the contract. Now, in the `usePrepareContractWrite` we re-compute the price using the block timestamp to ensure it is the most accurate.